### PR TITLE
feat: persist notes to localStorage

### DIFF
--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -1,12 +1,21 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { chatWithLLM } from '../lib/llm'
 
 export default function Notes() {
-  const [content, setContent] = useState('')
+  const [content, setContent] = useState(() => localStorage.getItem('notes') || '')
   const [prompt, setPrompt] = useState('')
   const [reply, setReply] = useState('')
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    localStorage.setItem('notes', content)
+  }, [content])
+
+  const clearNotes = () => {
+    setContent('')
+    localStorage.removeItem('notes')
+  }
 
   const send = async () => {
     if (!prompt.trim()) return
@@ -33,6 +42,12 @@ export default function Notes() {
         <div className="border rounded p-2 min-h-[160px] bg-white">
           <ReactMarkdown>{content}</ReactMarkdown>
         </div>
+        <button
+          className="h-9 px-4 rounded-xl bg-gray-200 text-sm hover:bg-gray-300 active:scale-[0.98]"
+          onClick={clearNotes}
+        >
+          清空笔记
+        </button>
       </div>
       <div className="grid gap-2">
         <textarea


### PR DESCRIPTION
## Summary
- persist Notes content in localStorage and load saved text on mount
- add button to clear notes and remove stored entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba9a134d2c8331a8e5b8d622a2815d