### PR TITLE
feat: add chat page with markdown editor and LLM integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
+# 配置后可与外部大模型对话
 VITE_LLM_API_URL=https://api.example.com/chat
 VITE_LLM_API_KEY=YOUR_API_KEY

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ yarn && yarn dev
 
 如需调用外部大模型 API，请复制 `.env.example` 为 `.env` 并配置 `VITE_LLM_API_URL` 与 `VITE_LLM_API_KEY`。
 
+```bash
+VITE_LLM_API_URL=https://api.example.com/chat
+VITE_LLM_API_KEY=sk-xxxxx
+```
+
+配置完成后启动服务，在侧栏点击“对话”即可与外部大模型交流。
+
 ## 功能点（MVP）
 - 网站管理：新增、打开、删除
 - 密码库：本地零知识加密（PBKDF2 + AES-GCM），复制时解密到剪贴板

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ export default function Sidebar() {
         <NavLink to="/sites" className={linkClass}>网站</NavLink>
         <NavLink to="/vault" className={linkClass}>密码库</NavLink>
         <NavLink to="/docs" className={linkClass}>文档</NavLink>
+        <NavLink to="/chat" className={linkClass}>对话</NavLink>
         <NavLink to="/settings" className={linkClass}>设置</NavLink>
       </nav>
 

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,21 +1,124 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, KeyboardEvent } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { chatWithLLM } from '../lib/llm'
+
+interface Message {
+  role: 'user' | 'assistant'
+  text: string
+}
+
+export default function Chat() {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [note, setNote] = useState('')
+  const [showEditor, setShowEditor] = useState(true)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, loading])
+
+  const send = async () => {
+    if (!input.trim()) return
+    const userMsg: Message = { role: 'user', text: input }
+    setMessages(m => [...m, userMsg])
+    setInput('')
+    setLoading(true)
+    try {
+      const reply = await chatWithLLM(userMsg.text)
+      setMessages(m => [...m, { role: 'assistant', text: reply }])
     } finally {
       setLoading(false)
     }
   }
-              ) : (
-                m.text
-              )}
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      send()
+    }
+  }
+
+  return (
+    <div className="flex h-full relative">
+      <div className="flex-1 flex flex-col">
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {messages.map((m, i) => (
+            <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`max-w-[80%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap ${
+                  m.role === 'user' ? 'bg-green-100' : 'bg-gray-50'
+                }`}
+              >
+                {m.role === 'assistant' ? (
+                  <ReactMarkdown
+                    components={{
+                      code({ inline, ...props }) {
+                        return inline ? (
+                          <code className="bg-green-200 text-green-800 rounded px-1" {...props} />
+                        ) : (
+                          <pre className="bg-green-100 p-2 rounded overflow-x-auto"><code {...props} /></pre>
+                        )
+                      },
+                      a(props) {
+                        return <a className="text-green-700 underline" target="_blank" rel="noreferrer" {...props} />
+                      }
+                    }}
+                  >
+                    {m.text}
+                  </ReactMarkdown>
+                ) : (
+                  m.text
+                )}
+              </div>
             </div>
+          ))}
+          {loading && <div className="text-gray-400 text-sm">…</div>}
+          <div ref={bottomRef} />
+        </div>
+        <div className="p-4 border-t">
+          <textarea
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="输入消息，Enter 发送，Shift+Enter 换行"
+            className="w-full border rounded p-2 text-sm h-24 resize-none"
+          />
+          <div className="text-right mt-2">
+            <button
+              onClick={send}
+              disabled={loading}
+              className="px-3 py-1 bg-green-600 text-white text-sm rounded disabled:opacity-50"
+            >
+              发送
+            </button>
           </div>
-        ))}
-        <div ref={bottomRef} />
+        </div>
       </div>
 
+      {showEditor ? (
+        <div className="w-1/3 border-l flex flex-col">
+          <div className="p-2 border-b text-right">
+            <button onClick={() => setShowEditor(false)} className="text-xs text-gray-500">
+              折叠
+            </button>
+          </div>
+          <textarea
+            value={note}
+            onChange={e => setNote(e.target.value)}
+            placeholder="Markdown 笔记"
+            className="flex-1 p-2 text-sm resize-none"
+          />
+        </div>
+      ) : (
+        <button
+          onClick={() => setShowEditor(true)}
+          className="absolute right-0 top-1/2 -translate-y-1/2 bg-gray-200 text-xs px-2 py-1 rounded-l"
+        >
+          展开编辑器
         </button>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -4,6 +4,7 @@ import Sites from './pages/Sites'
 import Vault from './pages/Vault'
 import Docs from './pages/Docs'
 import Settings from './pages/Settings'
+import Chat from './pages/Chat'
 import App from './App'
 
 export const router = createBrowserRouter([
@@ -15,6 +16,7 @@ export const router = createBrowserRouter([
       { path: 'sites', element: <Sites /> },
       { path: 'vault', element: <Vault /> },
       { path: 'docs', element: <Docs /> },
+      { path: 'chat', element: <Chat /> },
       { path: 'settings', element: <Settings /> }
     ]
   }


### PR DESCRIPTION
## Summary
- rename notes page to Chat and add flex layout chat UI with collapsible Markdown editor
- wire up sidebar and routes with new Chat page
- document LLM API configuration and usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bae8af4d508331920f48051d687b7c