### PR TITLE
feat: refresh styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 基于 React + TypeScript + Vite + Tailwind + Zustand + Dexie (IndexedDB) 的个人管理系统最小可运行骨架。
 
+界面风格参考 Notion，基础配色与字体可在 `tailwind.config.js` 中自定义覆盖。
+
 ## 本地运行
 
 ```bash

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ export default function Sidebar() {
       (isActive ? 'bg-blue-50 text-blue-700 border-blue-600' : 'border-transparent')
 
   return (
-    <aside className="border-r p-3 text-sm space-y-3 w-[220px]">
+    <aside className="max-w-screen-lg mx-auto px-6 py-4 text-sm space-y-3 rounded-2xl shadow-sm border-r bg-white">
       <nav className="space-y-1">
         <NavLink to="/" end className={linkClass}>工作台</NavLink>
         <NavLink to="/sites" className={linkClass}>网站</NavLink>

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -236,11 +236,18 @@ export default function Topbar() {
         <div className="grid gap-3">
           <Input type="password" placeholder="请输入主密码" value={mpw} onChange={e => setMpw(e.target.value)} />
           <div className="flex justify-end gap-2">
-            <button className="h-9 px-4 rounded-xl border text-sm" onClick={() => setOpenUnlock(false)}>取消</button>
             <button
-              className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+              onClick={() => setOpenUnlock(false)}
+            >
+              取消
+            </button>
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={() => { unlock(mpw); setMpw(''); setOpenUnlock(false) }}
-            >解锁</button>
+            >
+              解锁
+            </button>
           </div>
         </div>
       </Modal>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -4,11 +4,11 @@ import React from 'react'
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: 'primary'|'secondary'|'danger'|'ghost', size?: 'sm'|'md'|'lg' }
 export default function Button({ className, variant='primary', size='md', ...props }: Props) {
   const v = {
-    primary: 'bg-black text-white hover:bg-black/90 border-transparent',
-    secondary: 'bg-white text-black hover:bg-gray-50 border-gray-300',
-    danger: 'bg-red-600 text-white hover:bg-red-500 border-transparent',
-    ghost: 'bg-transparent text-black hover:bg-black/5 border-transparent'
+    primary: 'bg-gray-100 text-gray-800 hover:bg-gray-200 border-gray-300',
+    secondary: 'bg-white text-gray-800 hover:bg-gray-50 border-gray-300',
+    danger: 'bg-red-50 text-red-700 hover:bg-red-100 border-red-200',
+    ghost: 'bg-transparent text-gray-800 hover:bg-gray-100 border-transparent',
   }[variant]
   const s = { sm:'h-8 px-2 text-sm', md:'h-9 px-3', lg:'h-10 px-4 text-lg' }[size]
-  return <button {...props} className={clsx('rounded border transition-colors disabled:opacity-50', v, s, className)} />
+  return <button {...props} className={clsx('rounded border shadow-sm transition-colors disabled:opacity-50', v, s, className)} />
 }

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -13,7 +13,7 @@ export default function IconButton({ className, srLabel, size='md', children, ..
       {...props}
       title={srLabel}
       aria-label={srLabel}
-      className={clsx('inline-flex items-center justify-center rounded-lg border border-transparent bg-white text-gray-700 hover:bg-gray-50 active:bg-gray-100 shadow-sm hover:shadow transition-all disabled:opacity-50', s, className)}
+      className={clsx('inline-flex items-center justify-center rounded-lg border border-gray-300 bg-gray-100 text-gray-800 hover:bg-gray-200 shadow-sm transition-colors disabled:opacity-50', s, className)}
     >
       <span className="sr-only">{srLabel}</span>
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: light; --bg:#f7f7f9; --panel:#ffffff; }
-html, body, #root { height: 100%; background: var(--bg); color: #111827; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, 'Noto Sans', 'Helvetica Neue', Arial, 'Apple Color Emoji', 'Segoe UI Emoji'; }
+:root { color-scheme: light; }
+html, body, #root { height: 100%; }
+body { @apply font-sans bg-[#f7f6f3] text-[#2d2d2d]; }
 table { border-collapse: collapse; }
 th, td { border-color: #eee; }
 a { color: #2563eb }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { router } from './routes'
-import './styles/global.css'
+import './index.css'
 
 import { toast } from './utils/toast'
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,7 +11,7 @@ export default function Dashboard() {
   const docs = items.filter(i => i.type === 'doc') as DocItem[]
 
   return (
-    <div className="p-4 space-y-6">
+    <div className="max-w-screen-lg mx-auto px-6 py-4 space-y-6 bg-white rounded-2xl shadow-sm">
       <section>
         <h1 className="text-xl font-semibold mb-3">常用与最近</h1>
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -147,12 +147,17 @@ export default function Docs() {
   const ui = (
     <div className="h-[calc(100dvh-48px)] overflow-auto">
       <div className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b">
-        <div className="max-w-7xl mx-auto p-3 flex items-center gap-3">
+        <div className="max-w-screen-lg mx-auto px-6 py-3 flex items-center gap-3 rounded-2xl shadow-sm bg-white">
           <Input placeholder="搜索…" value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
           <Segmented value={view} onChange={setView} options={[{ label: '表格', value: 'table' }, { label: '卡片', value: 'card' }]} />
-          <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]" onClick={() => setOpenNew(true)}>新建</button>
+          <button
+            className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-gray-800 text-sm shadow-sm hover:bg-gray-200"
+            onClick={() => setOpenNew(true)}
+          >
+            新建
+          </button>
         </div>
-        <div className="max-w-7xl mx-auto px-3 pb-2">
+        <div className="max-w-screen-lg mx-auto px-6 pb-2">
           <TagRow />
           {selection.size > 0 && (
             <div className="mt-2 flex items-center gap-2">
@@ -166,7 +171,7 @@ export default function Docs() {
           )}
         </div>
       </div>
-      <div className="max-w-7xl mx-auto p-3">{view === 'table' ? tableView : cardView}</div>
+      <div className="max-w-screen-lg mx-auto px-6 py-3 bg-white rounded-2xl shadow-sm">{view === 'table' ? tableView : cardView}</div>
     </div>
   )
 
@@ -181,13 +186,20 @@ export default function Docs() {
         title="新建文档"
         footer={
           <>
-            <button className="h-9 px-4 rounded-xl border text-sm" onClick={() => setOpenNew(false)}>取消</button>
-            <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+              onClick={() => setOpenNew(false)}
+            >
+              取消
+            </button>
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={async () => {
                 if (!nTitle || !nPath) { alert('请填写完整'); return }
                 await addDoc({ title: nTitle, path: nPath, source: 'local', tags: nTags })
                 setOpenNew(false); setNTitle(''); setNPath(''); setNTags([])
-              }}>
+              }}
+            >
               保存
             </button>
           </>
@@ -210,13 +222,20 @@ export default function Docs() {
               <a className="h-9 px-3 rounded-xl border grid place-items-center mr-auto"
                  href={edit.path} target="_blank" rel="noreferrer">打开</a>
             )}
-            <button className="h-9 px-4 rounded-xl border text-sm" onClick={() => setOpenEdit(false)}>取消</button>
-            <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+              onClick={() => setOpenEdit(false)}
+            >
+              取消
+            </button>
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={async () => {
                 if (!edit) return
                 await update(edit.id, { title: edit.title, path: edit.path, description: edit.description, tags: edit.tags })
                 setOpenEdit(false)
-              }}>
+              }}
+            >
               保存
             </button>
           </>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,7 +11,7 @@ export default function Settings() {
   const [hint, setHint] = useState('')
 
   return (
-    <div className="p-4 space-y-6 text-sm">
+    <div className="max-w-screen-lg mx-auto px-6 py-4 space-y-6 text-sm bg-white rounded-2xl shadow-sm">
       <section>
         <h2 className="text-lg font-medium mb-2">导入 / 导出</h2>
         <div className="flex items-center gap-2">

--- a/src/pages/Sites.tsx
+++ b/src/pages/Sites.tsx
@@ -163,12 +163,17 @@ export default function Sites() {
   const ui = (
     <div className="h-[calc(100dvh-48px)] overflow-auto">
       <div className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b">
-        <div className="max-w-7xl mx-auto p-3 flex items-center gap-3">
+        <div className="max-w-screen-lg mx-auto px-6 py-3 flex items-center gap-3 rounded-2xl shadow-sm bg-white">
           <Input placeholder="搜索…" value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
           <Segmented value={view} onChange={setView} options={[{ label: '表格', value: 'table' }, { label: '卡片', value: 'card' }]} />
-          <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]" onClick={() => setOpenNew(true)}>新建</button>
+          <button
+            className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-gray-800 text-sm shadow-sm hover:bg-gray-200"
+            onClick={() => setOpenNew(true)}
+          >
+            新建
+          </button>
         </div>
-        <div className="max-w-7xl mx-auto px-3 pb-2">
+        <div className="max-w-screen-lg mx-auto px-6 pb-2">
           <TagRow />
           {selection.size > 0 && (
             <div className="mt-2 flex items-center gap-2">
@@ -182,7 +187,7 @@ export default function Sites() {
           )}
         </div>
       </div>
-      <div className="max-w-7xl mx-auto p-3">{view === 'table' ? tableView : cardView}</div>
+      <div className="max-w-screen-lg mx-auto px-6 py-3 bg-white rounded-2xl shadow-sm">{view === 'table' ? tableView : cardView}</div>
     </div>
   )
 
@@ -197,13 +202,20 @@ export default function Sites() {
         title="新建站点"
         footer={
           <>
-            <button className="h-9 px-4 rounded-xl border text-sm" onClick={() => setOpenNew(false)}>取消</button>
-            <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+              onClick={() => setOpenNew(false)}
+            >
+              取消
+            </button>
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={async () => {
                 if (!nTitle || !nUrl) { alert('请填写标题和地址'); return }
                 await addSite({ title: nTitle, url: nUrl, description: nDesc, tags: nTags })
                 setOpenNew(false); setNTitle(''); setNUrl(''); setNDesc(''); setNTags([])
-              }}>
+              }}
+            >
               保存
             </button>
           </>
@@ -227,13 +239,20 @@ export default function Sites() {
               <a className="h-9 px-3 rounded-xl border grid place-items-center mr-auto"
                  href={edit.url} target="_blank" rel="noreferrer">打开</a>
             )}
-            <button className="h-9 px-4 rounded-xl border text-sm" onClick={() => setOpenEdit(false)}>取消</button>
-            <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+              onClick={() => setOpenEdit(false)}
+            >
+              取消
+            </button>
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={async () => {
                 if (!edit) return
                 await update(edit.id, { title: edit.title, url: edit.url, description: edit.description, tags: edit.tags })
                 setOpenEdit(false)
-              }}>
+              }}
+            >
               保存
             </button>
           </>

--- a/src/pages/Vault.tsx
+++ b/src/pages/Vault.tsx
@@ -168,15 +168,17 @@ export default function Vault() {
   const ui = (
     <div className="h-[calc(100dvh-48px)] overflow-auto">
       <div className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b">
-        <div className="max-w-7xl mx-auto p-3 flex items-center gap-3">
+        <div className="max-w-screen-lg mx-auto px-6 py-3 flex items-center gap-3 rounded-2xl shadow-sm bg-white">
           <Input placeholder="搜索…" value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
           <Segmented value={view} onChange={setView} options={[{ label: '表格', value: 'table' }, { label: '卡片', value: 'card' }]} />
-          <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
-                  onClick={() => { if (ensureUnlocked()) setOpenNew(true) }}>
+          <button
+            className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-gray-800 text-sm shadow-sm hover:bg-gray-200"
+            onClick={() => { if (ensureUnlocked()) setOpenNew(true) }}
+          >
             新建
           </button>
         </div>
-        <div className="max-w-7xl mx-auto px-3 pb-2">
+        <div className="max-w-screen-lg mx-auto px-6 pb-2">
           <TagRow />
           {selection.size > 0 && (
             <div className="mt-2 flex items-center gap-2">
@@ -190,7 +192,7 @@ export default function Vault() {
           )}
         </div>
       </div>
-      <div className="max-w-7xl mx-auto p-3">{view === 'table' ? tableView : cardView}</div>
+      <div className="max-w-screen-lg mx-auto px-6 py-3 bg-white rounded-2xl shadow-sm">{view === 'table' ? tableView : cardView}</div>
     </div>
   )
 
@@ -205,15 +207,22 @@ export default function Vault() {
         title="新建密码"
         footer={
           <>
-            <button className="h-9 px-4 rounded-xl border text-sm" onClick={() => setOpenNew(false)}>取消</button>
-            <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
-              onClick={async () => {
+              <button
+                className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+                onClick={() => setOpenNew(false)}
+              >
+                取消
+              </button>
+              <button
+                className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+                onClick={async () => {
                 if (!unlocked || !master) { window.dispatchEvent(new CustomEvent('open-unlock')); return }
                 if (!nTitle || !nUser || !nPass) { alert('请填写完整'); return }
                 const cipher = await encryptString(master, nPass)
                 await addPassword({ title: nTitle, url: nUrl || undefined, username: nUser, passwordCipher: cipher, tags: nTags })
                 setOpenNew(false); setNTitle(''); setNUrl(''); setNUser(''); setNPass(''); setNTags([])
-              }}>
+              }}
+            >
               保存
             </button>
           </>
@@ -238,9 +247,15 @@ export default function Vault() {
               <a className="h-9 px-3 rounded-xl border grid place-items-center mr-auto"
                  href={edit.url} target="_blank" rel="noreferrer">打开</a>
             )}
-            <button className="h-9 px-4 rounded-xl border text-sm" onClick={() => setOpenEdit(false)}>取消</button>
-            <button className="h-9 px-4 rounded-xl bg-blue-600 text-white text-sm hover:bg-blue-700 active:scale-[0.98]"
-              onClick={async () => {
+              <button
+                className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+                onClick={() => setOpenEdit(false)}
+              >
+                取消
+              </button>
+              <button
+                className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+                onClick={async () => {
                 if (!edit) return
                 const patch: Partial<PasswordItem> = {
                   title: edit.title, url: edit.url, username: edit.username, tags: edit.tags
@@ -251,7 +266,8 @@ export default function Vault() {
                 }
                 await update(edit.id, patch)
                 setOpenEdit(false); setNewPass('')
-              }}>
+              }}
+            >
               保存
             </button>
           </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,16 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'Helvetica Neue', 'Arial', 'sans-serif'],
+      },
+      colors: {
+        background: '#f7f6f3',
+        text: '#2d2d2d',
+      },
+    },
+  },
   plugins: []
 }


### PR DESCRIPTION
## Summary
- apply Notion-like typography and colors via Tailwind config
- restyle layout containers and buttons for a softer aesthetic
- document theming in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae8aefc288331837e72b8c484710f