### PR TITLE
feat: customizable view and language settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react-dom": "^18.2.22",
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.19",
+        "fake-indexeddb": "^6.2.2",
         "postcss": "^8.4.41",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.5.4",
@@ -3992,6 +3993,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.2.tgz",
+      "integrity": "sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.2",
     "vite-plugin-pwa": "^0.20.5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "fake-indexeddb": "^6.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.21(postcss@8.5.6)
+      fake-indexeddb:
+        specifier: ^6.2.2
+        version: 6.2.2
       postcss:
         specifier: ^8.4.41
         version: 8.5.6
@@ -1377,6 +1380,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.2:
+    resolution: {integrity: sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4118,6 +4125,8 @@ snapshots:
   expect-type@1.2.2: {}
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.2: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,51 @@
+import { useSettings, Language } from '../store/useSettings'
+
+const dict = {
+  zh: {
+    search: '搜索…',
+    new: '新建',
+    table: '表格',
+    card: '卡片',
+    importExport: '导入 / 导出',
+    sites: '站点',
+    docs: '文档',
+    view: '自定义视图',
+    default: '默认',
+    list: '列表',
+    language: '语言',
+    master: '设置主密码',
+    save: '保存',
+    cancel: '取消',
+    chinese: '中文',
+    english: 'English'
+  },
+  en: {
+    search: 'Search…',
+    new: 'New',
+    table: 'Table',
+    card: 'Card',
+    importExport: 'Import / Export',
+    sites: 'Sites',
+    docs: 'Docs',
+    view: 'Default View',
+    default: 'Default',
+    list: 'List',
+    language: 'Language',
+    master: 'Set Master Password',
+    save: 'Save',
+    cancel: 'Cancel',
+    chinese: 'Chinese',
+    english: 'English'
+  }
+}
+
+export type TKey = keyof typeof dict['zh']
+
+export function translate(lang: Language, key: TKey): string {
+  return dict[lang][key]
+}
+
+export function useTranslation() {
+  const lang = useSettings(s => s.language)
+  return (key: TKey) => translate(lang, key)
+}

--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -10,6 +10,8 @@ import TagPicker from '../components/TagPicker'
 import { useSearchParams } from 'react-router-dom'
 import { Trash2, XCircle } from 'lucide-react'
 import FixedUrl from '../components/FixedUrl'
+import { useSettings } from '../store/useSettings'
+import { useTranslation } from '../lib/i18n'
 
 function Field({ label, children }: { label: string; children: any }) {
   return (
@@ -22,9 +24,11 @@ function Field({ label, children }: { label: string; children: any }) {
 
 export default function Docs() {
   const { items, load, addDoc, update, removeMany, selection, toggleSelect, clearSelection } = useItems()
+  const { view: prefView } = useSettings()
+  const t = useTranslation()
 
   const [q, setQ] = useState('')
-  const [view, setView] = useState<'table' | 'card'>('table')
+  const [view, setView] = useState<'table' | 'card'>(() => (prefView === 'card' ? 'card' : prefView === 'list' ? 'table' : 'table'))
   const [params] = useSearchParams()
   const activeTag = params.get('tag')
 
@@ -39,6 +43,11 @@ export default function Docs() {
   const [edit, setEdit] = useState<DocItem | null>(null)
 
   useEffect(() => { load() }, [])
+
+  useEffect(() => {
+    if (prefView === 'card') setView('card')
+    else if (prefView === 'list') setView('table')
+  }, [prefView])
 
   // 顶部搜索：定位+高亮
   useEffect(() => {
@@ -148,13 +157,13 @@ export default function Docs() {
     <div className="h-[calc(100dvh-48px)] overflow-auto">
       <div className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b">
         <div className="max-w-screen-lg mx-auto px-6 py-3 flex items-center gap-3 rounded-2xl shadow-sm bg-white">
-          <Input placeholder="搜索…" value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
-          <Segmented value={view} onChange={setView} options={[{ label: '表格', value: 'table' }, { label: '卡片', value: 'card' }]} />
+          <Input placeholder={t('search')} value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
+          <Segmented value={view} onChange={setView} options={[{ label: t('table'), value: 'table' }, { label: t('card'), value: 'card' }]} />
           <button
             className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-gray-800 text-sm shadow-sm hover:bg-gray-200"
             onClick={() => setOpenNew(true)}
           >
-            新建
+            {t('new')}
           </button>
         </div>
         <div className="max-w-screen-lg mx-auto px-6 pb-2">
@@ -190,7 +199,7 @@ export default function Docs() {
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={() => setOpenNew(false)}
             >
-              取消
+              {t('cancel')}
             </button>
             <button
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
@@ -200,7 +209,7 @@ export default function Docs() {
                 setOpenNew(false); setNTitle(''); setNPath(''); setNTags([])
               }}
             >
-              保存
+              {t('save')}
             </button>
           </>
         }>
@@ -226,7 +235,7 @@ export default function Docs() {
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={() => setOpenEdit(false)}
             >
-              取消
+              {t('cancel')}
             </button>
             <button
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
@@ -236,7 +245,7 @@ export default function Docs() {
                 setOpenEdit(false)
               }}
             >
-              保存
+              {t('save')}
             </button>
           </>
         }>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,65 +1,101 @@
-import { Upload, Download, Save, Wand2 } from 'lucide-react'
+import { Download } from 'lucide-react'
 import IconButton from '../components/ui/IconButton'
-import { toast } from '../utils/toast'
-import { useItems } from '../store/useItems'
-import { parseNetscapeHTML } from '../lib/bookmarks'
 import Input from '../components/ui/Input'
+import { useItems } from '../store/useItems'
+import { useSettings } from '../store/useSettings'
+import { useAuth } from '../store/useAuth'
+import { useTranslation } from '../lib/i18n'
 import { useState } from 'react'
 
 export default function Settings() {
-  const { exportJSON, importJSON, addSite } = useItems()
-  const [hint, setHint] = useState('')
+  const { exportSites, importSites, exportDocs, importDocs } = useItems()
+  const { view, setView, language, setLanguage } = useSettings()
+  const { master, setMaster } = useAuth()
+  const [mpw, setMpw] = useState(master || '')
+  const t = useTranslation()
 
   return (
     <div className="max-w-screen-lg mx-auto px-6 py-4 space-y-6 text-sm bg-white rounded-2xl shadow-sm">
       <section>
-        <h2 className="text-lg font-medium mb-2">导入 / 导出</h2>
+        <h2 className="text-lg font-medium mb-2">{t('importExport')} - {t('sites')}</h2>
         <div className="flex items-center gap-2">
-          <IconButton srLabel="导出 JSON" onClick={async () => {
-            const blob = await exportJSON()
+          <IconButton srLabel={t('importExport')} onClick={async () => {
+            const blob = await exportSites()
             const url = URL.createObjectURL(blob)
             const a = document.createElement('a')
-            a.href = url; a.download = 'pms-export.json'; a.click()
+            a.href = url; a.download = 'sites.json'; a.click()
             URL.revokeObjectURL(url)
           }}>
             <Download className="w-4 h-4" />
           </IconButton>
           <label className="inline-flex items-center gap-2">
-            <input type="file" accept="application/json" onChange={e=>{
+            <input type="file" accept="application/json" onChange={e => {
               const f = e.target.files?.[0]; if (!f) return
-              importJSON(f)
-            }}/>
-            导入 JSON
-          </label>
-        </div>
-      </section>
-
-      <section>
-        <h2 className="text-lg font-medium mb-2">浏览器书签导入</h2>
-        <div className="space-y-2">
-          <label className="inline-flex items-center gap-2">
-            <input type="file" accept=".html,.htm" onChange={async e=>{
-              const f = e.target.files?.[0]; if (!f) return
-              const links = await parseNetscapeHTML(f)
-              let count = 0
-              for (const l of links.slice(0, 1000)) { // 安全天花板
-                try { await addSite({ title: l.title || l.url, url: l.url, description: '', tags: [] }); count++ } catch {}
-              }
-              toast.info(`已导入 ${count} 条链接`)
+              importSites(f)
             }} />
-            选择从浏览器导出的 HTML 书签文件
+            {t('importExport')}
           </label>
-          <div className="text-xs text-gray-500">目前仅解析 &lt;A HREF="..."&gt;，后续迭代支持文件夹→标签映射、去重。</div>
         </div>
       </section>
 
       <section>
-        <h2 className="text-lg font-medium mb-2">安全</h2>
-        <div className="space-y-2">
-          <div>主密码提示（本地保存，不加密，仅为提示用途）</div>
-          <Input className="w-80" placeholder="例如：你常用的一句歌词" value={hint} onChange={e=>setHint(e.target.value)} />
-          <div className="text-xs text-gray-500">后续会与“自动锁定/剪贴板清除”策略一起配置。</div>
+        <h2 className="text-lg font-medium mb-2">{t('importExport')} - {t('docs')}</h2>
+        <div className="flex items-center gap-2">
+          <IconButton srLabel={t('importExport')} onClick={async () => {
+            const blob = await exportDocs()
+            const url = URL.createObjectURL(blob)
+            const a = document.createElement('a')
+            a.href = url; a.download = 'docs.json'; a.click()
+            URL.revokeObjectURL(url)
+          }}>
+            <Download className="w-4 h-4" />
+          </IconButton>
+          <label className="inline-flex items-center gap-2">
+            <input type="file" accept="application/json" onChange={e => {
+              const f = e.target.files?.[0]; if (!f) return
+              importDocs(f)
+            }} />
+            {t('importExport')}
+          </label>
         </div>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">{t('view')}</h2>
+        <select
+          className="border rounded px-2 py-1"
+          value={view}
+          onChange={e => setView(e.target.value as any)}
+        >
+          <option value="default">{t('default')}</option>
+          <option value="card">{t('card')}</option>
+          <option value="list">{t('list')}</option>
+        </select>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">{t('master')}</h2>
+        <div className="flex items-center gap-2">
+          <Input type="password" className="w-80" value={mpw} onChange={e => setMpw(e.target.value)} />
+          <button
+            className="h-8 px-3 rounded-xl border border-gray-300 bg-gray-100 text-gray-800 shadow-sm"
+            onClick={() => setMaster(mpw)}
+          >
+            {t('save')}
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium mb-2">{t('language')}</h2>
+        <select
+          className="border rounded px-2 py-1"
+          value={language}
+          onChange={e => setLanguage(e.target.value as any)}
+        >
+          <option value="zh">{t('chinese')}</option>
+          <option value="en">{t('english')}</option>
+        </select>
       </section>
     </div>
   )

--- a/src/pages/Sites.tsx
+++ b/src/pages/Sites.tsx
@@ -10,6 +10,8 @@ import TagPicker from '../components/TagPicker'
 import { useSearchParams } from 'react-router-dom'
 import { ExternalLink, Trash2, XCircle } from 'lucide-react'
 import FixedUrl from '../components/FixedUrl'
+import { useSettings } from '../store/useSettings'
+import { useTranslation } from '../lib/i18n'
 
 function Field({ label, children }: { label: string; children: any }) {
   return (
@@ -22,8 +24,10 @@ function Field({ label, children }: { label: string; children: any }) {
 
 export default function Sites() {
   const { items, load, addSite, update, removeMany, selection, toggleSelect, clearSelection } = useItems()
+  const { view: prefView } = useSettings()
+  const t = useTranslation()
   const [q, setQ] = useState('')
-  const [view, setView] = useState<'table' | 'card'>('table')
+  const [view, setView] = useState<'table' | 'card'>(() => (prefView === 'card' ? 'card' : prefView === 'list' ? 'table' : 'table'))
   const [params] = useSearchParams()
   const activeTag = params.get('tag')
 
@@ -39,6 +43,11 @@ export default function Sites() {
   const [edit, setEdit] = useState<SiteItem | null>(null)
 
   useEffect(() => { load() }, [])
+
+  useEffect(() => {
+    if (prefView === 'card') setView('card')
+    else if (prefView === 'list') setView('table')
+  }, [prefView])
 
   useEffect(() => {
     const handler = (e: any) => {
@@ -164,13 +173,13 @@ export default function Sites() {
     <div className="h-[calc(100dvh-48px)] overflow-auto">
       <div className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b">
         <div className="max-w-screen-lg mx-auto px-6 py-3 flex items-center gap-3 rounded-2xl shadow-sm bg-white">
-          <Input placeholder="搜索…" value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
-          <Segmented value={view} onChange={setView} options={[{ label: '表格', value: 'table' }, { label: '卡片', value: 'card' }]} />
+          <Input placeholder={t('search')} value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
+          <Segmented value={view} onChange={setView} options={[{ label: t('table'), value: 'table' }, { label: t('card'), value: 'card' }]} />
           <button
             className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-gray-800 text-sm shadow-sm hover:bg-gray-200"
             onClick={() => setOpenNew(true)}
           >
-            新建
+            {t('new')}
           </button>
         </div>
         <div className="max-w-screen-lg mx-auto px-6 pb-2">
@@ -206,7 +215,7 @@ export default function Sites() {
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={() => setOpenNew(false)}
             >
-              取消
+              {t('cancel')}
             </button>
             <button
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
@@ -216,7 +225,7 @@ export default function Sites() {
                 setOpenNew(false); setNTitle(''); setNUrl(''); setNDesc(''); setNTags([])
               }}
             >
-              保存
+              {t('save')}
             </button>
           </>
         }>
@@ -243,7 +252,7 @@ export default function Sites() {
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
               onClick={() => setOpenEdit(false)}
             >
-              取消
+              {t('cancel')}
             </button>
             <button
               className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
@@ -253,7 +262,7 @@ export default function Sites() {
                 setOpenEdit(false)
               }}
             >
-              保存
+              {t('save')}
             </button>
           </>
         }>

--- a/src/pages/Vault.tsx
+++ b/src/pages/Vault.tsx
@@ -12,6 +12,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { ExternalLink, Trash2, XCircle } from 'lucide-react'
 import { encryptString } from '../lib/crypto'
 import { useSearchParams } from 'react-router-dom'
+import { useSettings } from '../store/useSettings'
+import { useTranslation } from '../lib/i18n'
 
 function Field({ label, children }: { label: string; children: any }) {
   return (
@@ -25,9 +27,11 @@ function Field({ label, children }: { label: string; children: any }) {
 export default function Vault() {
   const { items, load, addPassword, update, removeMany, selection, toggleSelect, clearSelection } = useItems()
   const { unlocked, master } = useAuth()
+  const { view: prefView } = useSettings()
+  const t = useTranslation()
 
   const [q, setQ] = useState('')
-  const [view, setView] = useState<'table' | 'card'>('table')
+  const [view, setView] = useState<'table' | 'card'>(() => (prefView === 'card' ? 'card' : prefView === 'list' ? 'table' : 'table'))
   const [params] = useSearchParams()
   const activeTag = params.get('tag')
 
@@ -45,6 +49,11 @@ export default function Vault() {
   const [newPass, setNewPass] = useState('')
 
   useEffect(() => { load() }, [])
+
+  useEffect(() => {
+    if (prefView === 'card') setView('card')
+    else if (prefView === 'list') setView('table')
+  }, [prefView])
 
   useEffect(() => {
     const handler = (e: any) => {
@@ -169,13 +178,13 @@ export default function Vault() {
     <div className="h-[calc(100dvh-48px)] overflow-auto">
       <div className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b">
         <div className="max-w-screen-lg mx-auto px-6 py-3 flex items-center gap-3 rounded-2xl shadow-sm bg-white">
-          <Input placeholder="搜索…" value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
-          <Segmented value={view} onChange={setView} options={[{ label: '表格', value: 'table' }, { label: '卡片', value: 'card' }]} />
+          <Input placeholder={t('search')} value={q} onChange={e => setQ(e.target.value)} className="flex-1" />
+          <Segmented value={view} onChange={setView} options={[{ label: t('table'), value: 'table' }, { label: t('card'), value: 'card' }]} />
           <button
             className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-gray-800 text-sm shadow-sm hover:bg-gray-200"
             onClick={() => { if (ensureUnlocked()) setOpenNew(true) }}
           >
-            新建
+            {t('new')}
           </button>
         </div>
         <div className="max-w-screen-lg mx-auto px-6 pb-2">
@@ -211,7 +220,7 @@ export default function Vault() {
                 className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
                 onClick={() => setOpenNew(false)}
               >
-                取消
+                {t('cancel')}
               </button>
               <button
                 className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
@@ -223,7 +232,7 @@ export default function Vault() {
                 setOpenNew(false); setNTitle(''); setNUrl(''); setNUser(''); setNPass(''); setNTags([])
               }}
             >
-              保存
+              {t('save')}
             </button>
           </>
         }>
@@ -251,7 +260,7 @@ export default function Vault() {
                 className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
                 onClick={() => setOpenEdit(false)}
               >
-                取消
+                {t('cancel')}
               </button>
               <button
                 className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
@@ -268,7 +277,7 @@ export default function Vault() {
                 setOpenEdit(false); setNewPass('')
               }}
             >
-              保存
+              {t('save')}
             </button>
           </>
         }>

--- a/src/store/useItems.test.ts
+++ b/src/store/useItems.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import { useItems } from './useItems'
+import { db } from '../lib/db'
+
+beforeEach(async () => {
+  await db.items.clear()
+})
+
+describe('items import/export', () => {
+  it('exports and imports sites', async () => {
+    const { addSite, exportSites, importSites, load } = useItems.getState()
+    await addSite({ title: 'Example', url: 'https://example.com', description: '', tags: [] })
+    const blob = await exportSites()
+    const text = await blob.text()
+    await db.items.clear(); await load()
+    const file: any = { text: async () => text }
+    await importSites(file)
+    expect(useItems.getState().items.length).toBe(1)
+    expect(useItems.getState().items[0].title).toBe('Example')
+  })
+
+  it('exports and imports docs', async () => {
+    const { addDoc, exportDocs, importDocs, load } = useItems.getState()
+    await addDoc({ title: 'Doc', path: '/a', source: 'local', tags: [] })
+    const blob = await exportDocs()
+    const text = await blob.text()
+    await db.items.clear(); await load()
+    const file: any = { text: async () => text }
+    await importDocs(file)
+    expect(useItems.getState().items.length).toBe(1)
+    expect(useItems.getState().items[0].title).toBe('Doc')
+  })
+})

--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -27,8 +27,10 @@ interface ItemState {
   clearSelection: () => void
   toggleSelect: (id: string, rangeWith?: string | null) => void
 
-  exportJSON: () => Promise<Blob>
-  importJSON: (file: File) => Promise<void>
+  exportSites: () => Promise<Blob>
+  importSites: (file: File) => Promise<void>
+  exportDocs: () => Promise<Blob>
+  importDocs: (file: File) => Promise<void>
 }
 
 export const useItems = create<ItemState>((set, get) => ({
@@ -122,18 +124,27 @@ export const useItems = create<ItemState>((set, get) => ({
     })
   },
 
-  async exportJSON() {
-    const [items, tags, settings] = await Promise.all([db.items.toArray(), db.tags.toArray(), db.settings.toArray()])
-    const blob = new Blob([JSON.stringify({ items, tags, settings }, null, 2)], { type: 'application/json' })
-    return blob
+  async exportSites() {
+    const items = await db.items.where('type').equals('site').toArray()
+    return new Blob([JSON.stringify(items, null, 2)], { type: 'application/json' })
   },
 
-  async importJSON(file) {
+  async importSites(file) {
     const text = await file.text()
-    const data = JSON.parse(text)
-    if (data.items) await db.items.bulkPut(data.items)
-    if (data.tags) await db.tags.bulkPut(data.tags)
-    if (data.settings) await db.settings.bulkPut(data.settings)
+    const data = JSON.parse(text) as SiteItem[]
+    if (Array.isArray(data)) await db.items.bulkPut(data.map(it => ({ ...it, type: 'site' })))
+    await get().load()
+  },
+
+  async exportDocs() {
+    const items = await db.items.where('type').equals('doc').toArray()
+    return new Blob([JSON.stringify(items, null, 2)], { type: 'application/json' })
+  },
+
+  async importDocs(file) {
+    const text = await file.text()
+    const data = JSON.parse(text) as DocItem[]
+    if (Array.isArray(data)) await db.items.bulkPut(data.map(it => ({ ...it, type: 'doc' })))
     await get().load()
   }
 }))

--- a/src/store/useSettings.test.ts
+++ b/src/store/useSettings.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { useSettings } from './useSettings'
+import { translate } from '../lib/i18n'
+
+describe('language switching', () => {
+  it('changes language text', () => {
+    const { setLanguage } = useSettings.getState()
+    setLanguage('en')
+    expect(useSettings.getState().language).toBe('en')
+    expect(translate('en', 'new')).toBe('New')
+    setLanguage('zh')
+    expect(translate('zh', 'new')).toBe('新建')
+  })
+})

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -1,12 +1,14 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
-interface AuthState {
-  unlocked: boolean
-  master?: string
-  unlock: (mpw: string) => void
-  lock: () => void
-  setMaster: (mpw: string) => void
+export type ViewPref = 'default' | 'card' | 'list'
+export type Language = 'zh' | 'en'
+
+interface SettingsState {
+  view: ViewPref
+  language: Language
+  setView: (v: ViewPref) => void
+  setLanguage: (l: Language) => void
 }
 
 const storage = {
@@ -24,19 +26,14 @@ const storage = {
   }
 }
 
-export const useAuth = create<AuthState>()(
+export const useSettings = create<SettingsState>()(
   persist(
     (set) => ({
-      unlocked: false,
-      master: undefined,
-      unlock: (mpw) => set({ unlocked: true, master: mpw }),
-      lock: () => set({ unlocked: false }),
-      setMaster: (mpw) => set({ master: mpw })
+      view: 'default',
+      language: 'zh',
+      setView: (v) => set({ view: v }),
+      setLanguage: (l) => set({ language: l })
     }),
-    {
-      name: 'auth',
-      storage: createJSONStorage(() => storage),
-      partialize: (state) => ({ master: state.master })
-    }
+    { name: 'settings', storage: createJSONStorage(() => storage) }
   )
 )


### PR DESCRIPTION
## Summary
- simplify settings and split site/doc import/export
- add global view and language preferences with persistence
- introduce master password form and tests for imports and language switching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbaa4b0da88331a1fb33746a0c65e1