### PR TITLE
docs: clarify offline default and external API risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ yarn && yarn dev
 - PWA 配置（vite-plugin-pwa）
 - 笔记：Markdown 编写与大模型对话
 
-> 仅本地离线可用；未接入任何云端服务。
+> 默认离线运行；如配置 `VITE_LLM_API_URL`/`VITE_LLM_API_KEY` 将访问外部服务，请自行评估隐私与安全风险。


### PR DESCRIPTION
## Summary
- note that the project runs offline unless VITE_LLM_API_URL/VITE_LLM_API_KEY are set
- warn users to assess privacy and security risks when using external APIs

## Testing
- `pnpm test` *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcd7ec8e48331bb3d87e25e95a2c2