### PR TITLE
Implement settings store and fix language usage

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,8 +5,8 @@ import { useSettings } from '../store/useSettings'
 
 export default function Sidebar() {
   const tags = useItems(s => s.tags)
-  const lang = useSettings(s => s.lang)
-  const text = lang === 'en'
+  const language = useSettings(s => s.language)
+  const text = language === 'en'
     ? { dashboard: 'Dashboard', sites: 'Sites', vault: 'Vault', docs: 'Docs', chat: 'Chat', settings: 'Settings', tags: 'Tags', none: '(no tags)' }
     : { dashboard: '工作台', sites: '网站', vault: '密码库', docs: '文档', chat: '对话', settings: '设置', tags: '标签', none: '（暂无标签）' }
   const linkClass =

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -1,1 +1,38 @@
+import { create } from 'zustand'
+
+export type Language = 'zh' | 'en'
+export type ViewMode = 'default' | 'card' | 'list'
+
+interface SettingsState {
+  language: Language
+  viewMode: ViewMode
+  setLanguage: (language: Language) => void
+  setViewMode: (mode: ViewMode) => void
+  load: () => void
+}
+
+export const useSettings = create<SettingsState>((set) => ({
+  language: 'zh',
+  viewMode: 'default',
+  setLanguage(language) {
+    set({ language })
+    try { localStorage.setItem('language', language) } catch { /* noop */ }
+  },
+  setViewMode(mode) {
+    set({ viewMode: mode })
+    try { localStorage.setItem('viewMode', mode) } catch { /* noop */ }
+  },
+  load() {
+    try {
+      const storedLang = localStorage.getItem('language') as Language | null
+      const storedView = localStorage.getItem('viewMode') as ViewMode | null
+      set({
+        language: storedLang ?? 'zh',
+        viewMode: storedView ?? 'default'
+      })
+    } catch {
+      /* noop */
+    }
+  }
+}))
 


### PR DESCRIPTION
## Summary
- add Zustand-based settings store with language and view preferences
- fix sidebar to reference language from settings store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbd980b0588331bd176d6513cad971