### PR TITLE
Implement settings store and fix language usage

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,8 +5,8 @@ import { useSettings } from '../store/useSettings'
 
 export default function Sidebar() {
   const tags = useItems(s => s.tags)
-  const lang = useSettings(s => s.lang)
-  const text = lang === 'en'
+  const language = useSettings(s => s.language)
+  const text = language === 'en'
     ? { dashboard: 'Dashboard', sites: 'Sites', vault: 'Vault', docs: 'Docs', chat: 'Chat', settings: 'Settings', tags: 'Tags', none: '(no tags)' }
     : { dashboard: '工作台', sites: '网站', vault: '密码库', docs: '文档', chat: '对话', settings: '设置', tags: '标签', none: '（暂无标签）' }
   const linkClass =

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -237,6 +237,21 @@ export default function Topbar() {
           <Input type="password" placeholder="请输入主密码" value={mpw} onChange={e => setMpw(e.target.value)} />
           <div className="flex justify-end gap-2">
             <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+              onClick={() => { setOpenUnlock(false); setMpw('') }}
+            >
+              取消
+            </button>
+            <button
+              className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200"
+              onClick={async () => {
+                const ok = await unlock(mpw)
+                if (ok) { setOpenUnlock(false); setMpw('') }
+                else { alert('主密码错误') }
+              }}
+            >
+              解锁
+            </button>
           </div>
         </div>
       </Modal>

--- a/src/store/useAuth.ts
+++ b/src/store/useAuth.ts
@@ -8,5 +8,44 @@ interface AuthState {
   setMaster: (pw: string) => Promise<void>
   unlock: (pw: string) => Promise<boolean>
   lock: () => void
-  setMaster: (mpw: string) => void
 }
+
+function hashString(str: string): Promise<string> {
+  const enc = new TextEncoder()
+  return crypto.subtle.digest('SHA-256', enc.encode(str)).then(buf => {
+    const bytes = new Uint8Array(buf)
+    return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
+  })
+}
+
+export const useAuth = create<AuthState>((set, get) => ({
+  unlocked: false,
+  master: undefined,
+  masterHash: undefined,
+  async load() {
+    try {
+      const masterHash = localStorage.getItem('masterHash') || undefined
+      set({ masterHash, unlocked: false, master: undefined })
+    } catch {
+      /* noop */
+    }
+  },
+  async setMaster(pw: string) {
+    const hash = await hashString(pw)
+    try { localStorage.setItem('masterHash', hash) } catch { /* noop */ }
+    set({ masterHash: hash, master: pw, unlocked: true })
+  },
+  async unlock(pw: string) {
+    const { masterHash } = get()
+    if (!masterHash) return false
+    const hash = await hashString(pw)
+    if (hash === masterHash) {
+      set({ unlocked: true, master: pw })
+      return true
+    }
+    return false
+  },
+  lock() {
+    set({ unlocked: false, master: undefined })
+  }
+}))

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -1,1 +1,38 @@
+import { create } from 'zustand'
+
+export type Language = 'zh' | 'en'
+export type ViewMode = 'default' | 'card' | 'list'
+
+interface SettingsState {
+  language: Language
+  viewMode: ViewMode
+  setLanguage: (language: Language) => void
+  setViewMode: (mode: ViewMode) => void
+  load: () => void
+}
+
+export const useSettings = create<SettingsState>((set) => ({
+  language: 'zh',
+  viewMode: 'default',
+  setLanguage(language) {
+    set({ language })
+    try { localStorage.setItem('language', language) } catch { /* noop */ }
+  },
+  setViewMode(mode) {
+    set({ viewMode: mode })
+    try { localStorage.setItem('viewMode', mode) } catch { /* noop */ }
+  },
+  load() {
+    try {
+      const storedLang = localStorage.getItem('language') as Language | null
+      const storedView = localStorage.getItem('viewMode') as ViewMode | null
+      set({
+        language: storedLang ?? 'zh',
+        viewMode: storedView ?? 'default'
+      })
+    } catch {
+      /* noop */
+    }
+  }
+}))
 


### PR DESCRIPTION
## Summary
- add Zustand-based settings store with language and view preferences
- fix sidebar to reference language from settings store
- implement auth store with basic master password handling
- finish unlock modal in Topbar to allow locking and unlocking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbd980b0588331bd176d6513cad971