### PR TITLE
feat(docs): add tag column

### DIFF
--- a/src/components/TagRow.tsx
+++ b/src/components/TagRow.tsx
@@ -34,7 +34,7 @@ export default function TagRow() {
   )
 }
 
-function TagChip({
+export function TagChip({
   id, name, color = 'gray', active, count, onClick, onDelete,
 }: { id: string; name: string; color?: string; active?: boolean; count?: number; onClick?: () => void; onDelete?: () => void }) {
   const palette: any = {

--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -5,7 +5,7 @@ import type { DocItem } from '../types'
 import Input from '../components/ui/Input'
 import Modal from '../components/ui/Modal'
 import Segmented from '../components/ui/Segmented'
-import TagRow from '../components/TagRow'
+import TagRow, { TagChip } from '../components/TagRow'
 import TagPicker from '../components/TagPicker'
 import { useSearchParams } from 'react-router-dom'
 import { Trash2, XCircle } from 'lucide-react'
@@ -22,7 +22,7 @@ function Field({ label, children }: { label: string; children: any }) {
 }
 
 export default function Docs() {
-  const { items, load, addDoc, update, removeMany, selection, toggleSelect, clearSelection } = useItems()
+  const { items, tags, load, addDoc, update, removeMany, selection, toggleSelect, clearSelection } = useItems()
   const [params] = useSearchParams()
   const activeTag = params.get('tag')
 
@@ -86,20 +86,24 @@ export default function Docs() {
     )
   }, [list, q, activeTag])
 
+  const tagMap = useMemo(() => Object.fromEntries(tags.map(t => [t.id, t])), [tags])
+
   // ======= 列表视图（均分列宽 + 右侧留白） =======
   const tableView = (
     <div className="overflow-auto border rounded-2xl">
       <table className="w-full table-fixed text-sm">
         <colgroup>
           <col style={{ width: '48px' }} />
-          <col style={{ width: '33.3333%' }} />
-          <col style={{ width: '33.3333%' }} />
-          <col style={{ width: '33.3333%' }} />
+          <col style={{ width: '25%' }} />
+          <col style={{ width: '25%' }} />
+          <col style={{ width: '25%' }} />
+          <col style={{ width: '25%' }} />
         </colgroup>
         <thead className="bg-gray-50">
           <tr className="text-left text-gray-500">
             <th className="px-3 py-2"></th>
             <th className="px-3 py-2">标题</th>
+            <th className="px-3 py-2">标签</th>
             <th className="px-3 py-2">路径/来源</th>
             <th className="px-3 py-2 text-right pr-4 md:pr-6">操作</th>
           </tr>
@@ -112,6 +116,16 @@ export default function Docs() {
                 <button className="hover:underline block truncate" title={it.title} onClick={() => { setEdit(it); setOpenEdit(true) }}>
                   {it.title}
                 </button>
+              </td>
+              <td className="px-3 py-2">
+                <div className="flex flex-wrap gap-1">
+                  {it.tags.map(tid => {
+                    const t = tagMap[tid]
+                    return t ? (
+                      <TagChip key={t.id} id={t.id} name={t.name} color={t.color || 'gray'} />
+                    ) : null
+                  })}
+                </div>
               </td>
               <td className="px-3 py-2">
                 <FixedUrl url={it.path} length={36} className="text-gray-600" stripProtocol={false} />


### PR DESCRIPTION
## Summary
- add tag column to Docs table view and display tags as TagChip
- export TagChip from TagRow for reuse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc043b13248331a9b41ab38d9fda17