### PR TITLE
feat: replace tag color select with swatches

### DIFF
--- a/src/components/TagPicker.tsx
+++ b/src/components/TagPicker.tsx
@@ -1,13 +1,27 @@
-import { Tag } from 'lucide-react'
+import { Tag as TagIcon } from 'lucide-react'
 import IconButton from './ui/IconButton'
 import React, { useState } from 'react'
 import { useItems } from '../store/useItems'
 import Input from './ui/Input'
+import clsx from 'clsx'
+import { TAG_COLORS, type TagColor } from '../types'
 
 export default function TagPicker({ value, onChange }: { value: string[]; onChange: (tags: string[]) => void }) {
   const { tags, addTag } = useItems()
   const [name, setName] = useState('')
-  const [color, setColor] = useState('gray')
+  const [color, setColor] = useState<TagColor>('gray')
+
+  const colorBg: Record<TagColor, string> = {
+    gray: 'bg-gray-400',
+    blue: 'bg-blue-400',
+    green: 'bg-green-400',
+    red: 'bg-red-400',
+    yellow: 'bg-yellow-400',
+    purple: 'bg-purple-400',
+    pink: 'bg-pink-400',
+    orange: 'bg-orange-400',
+    cyan: 'bg-cyan-400',
+  }
 
   return (
     <div className="space-y-2">
@@ -25,11 +39,37 @@ export default function TagPicker({ value, onChange }: { value: string[]; onChan
       </div>
 
       <div className="flex items-center gap-2">
-        <Input placeholder="新建标签名" value={name} onChange={e=>setName(e.target.value)} className="w-40" />
-        <select className="h-9 border rounded px-2" value={color} onChange={e=>setColor(e.target.value)}>
-          {['gray','blue','green','red','yellow','purple','pink','orange','cyan'].map(c => <option key={c} value={c}>{c}</option>)}
-        </select>
-        <IconButton size="sm" srLabel="新建标签" onClick={()=>{ if(!name.trim()) return; addTag({name, color}); setName('') }}><Tag className="w-4 h-4" /></IconButton>
+        <Input
+          placeholder="新建标签名"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          className="w-40"
+        />
+        <div className="flex items-center gap-1">
+          {TAG_COLORS.map(c => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setColor(c)}
+              className={clsx(
+                'w-5 h-5 rounded-full border-2',
+                color === c ? 'border-black' : 'border-transparent',
+                colorBg[c],
+              )}
+            />
+          ))}
+        </div>
+        <IconButton
+          size="sm"
+          srLabel="新建标签"
+          onClick={() => {
+            if (!name.trim()) return
+            addTag({ name, color })
+            setName('')
+          }}
+        >
+          <TagIcon className="w-4 h-4" />
+        </IconButton>
       </div>
     </div>
   )

--- a/src/components/TagRow.tsx
+++ b/src/components/TagRow.tsx
@@ -3,6 +3,7 @@ import { useItems } from '../store/useItems'
 import clsx from 'clsx'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { X } from 'lucide-react'
+import type { TagColor } from '../types'
 
 export default function TagRow() {
   const { items, tags, removeTag } = useItems()
@@ -35,9 +36,23 @@ export default function TagRow() {
 }
 
 function TagChip({
-  id, name, color = 'gray', active, count, onClick, onDelete,
-}: { id: string; name: string; color?: string; active?: boolean; count?: number; onClick?: () => void; onDelete?: () => void }) {
-  const palette: any = {
+  id,
+  name,
+  color = 'gray',
+  active,
+  count,
+  onClick,
+  onDelete,
+}: {
+  id: string
+  name: string
+  color?: TagColor
+  active?: boolean
+  count?: number
+  onClick?: () => void
+  onDelete?: () => void
+}) {
+  const palette: Record<TagColor, [string, string, string]> = {
     gray: ['bg-gray-100', 'text-gray-700', 'ring-gray-300'],
     blue: ['bg-blue-50', 'text-blue-700', 'ring-blue-300'],
     green: ['bg-green-50', 'text-green-700', 'ring-green-300'],

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,9 +1,9 @@
 import Dexie, { Table } from 'dexie'
-import type { AnyItem } from '../types'
+import type { AnyItem, Tag } from '../types'
 
 export class PMSDB extends Dexie {
   items!: Table<AnyItem, string>
-  tags!: Table<{ id: string; name: string; color?: string; parentId?: string }, string>
+  tags!: Table<Tag, string>
   settings!: Table<{ key: string; value: any }, string>
 
   constructor() {

--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -1,10 +1,11 @@
 import { create } from 'zustand'
 import { db } from '../lib/db'
-import type { AnyItem, SiteItem, PasswordItem, DocItem } from '../types'
+import type { AnyItem, SiteItem, PasswordItem, DocItem, Tag, TagColor }
+  from '../types'
+import { TAG_COLORS } from '../types'
 import { nanoid } from 'nanoid'
 
 type Filters = { type?: 'site'|'password'|'doc'; tags?: string[] }
-type Tag = { id: string; name: string; color?: string; parentId?: string }
 
 interface ItemState {
   items: AnyItem[]
@@ -22,7 +23,7 @@ interface ItemState {
   remove: (id: string) => Promise<void>
   removeMany: (ids: string[]) => Promise<void>
 
-  addTag: (p: {name: string; color?: string; parentId?: string}) => Promise<string>
+  addTag: (p: {name: string; color?: TagColor; parentId?: string}) => Promise<string>
   removeTag: (id: string) => Promise<void>
   setFilters: (f: Partial<Filters>) => void
   clearSelection: () => void
@@ -102,7 +103,9 @@ export const useItems = create<ItemState>((set, get) => ({
 
   async addTag(p) {
     const id = nanoid()
-    await db.tags.put({ id, ...p })
+    const { tags } = get()
+    const color = p.color ?? TAG_COLORS[tags.length % TAG_COLORS.length]
+    await db.tags.put({ id, ...p, color })
     await get().load()
     return id
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,33 @@ export interface DocItem extends BaseItem {
 }
 
 export type AnyItem = SiteItem | PasswordItem | DocItem
+
+export type TagColor =
+  | 'gray'
+  | 'blue'
+  | 'green'
+  | 'red'
+  | 'yellow'
+  | 'purple'
+  | 'pink'
+  | 'orange'
+  | 'cyan'
+
+export const TAG_COLORS: TagColor[] = [
+  'gray',
+  'blue',
+  'green',
+  'red',
+  'yellow',
+  'purple',
+  'pink',
+  'orange',
+  'cyan',
+]
+
+export interface Tag {
+  id: string
+  name: string
+  color: TagColor
+  parentId?: string
+}


### PR DESCRIPTION
## Summary
- replace TagPicker dropdown with clickable color swatches
- add TagColor type and default color assignment
- adapt TagRow and store for new tag color handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc045dfffc8331bb693d9e08312814