### PR TITLE
feat: add CSV import/export modal

### DIFF
--- a/src/components/ImportExportModal.tsx
+++ b/src/components/ImportExportModal.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import Modal from './ui/Modal'
+import { useItems } from '../store/useItems'
+
+export default function ImportExportModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { exportSites, exportDocs, importSites, importDocs } = useItems()
+  const [type, setType] = useState<'site' | 'doc'>('site')
+  const [file, setFile] = useState<File | null>(null)
+  const [preview, setPreview] = useState<any[]>([])
+  const [errors, setErrors] = useState<string[]>([])
+
+  async function handleExport(kind: 'site' | 'doc') {
+    const blob = kind === 'site' ? await exportSites() : await exportDocs()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = kind === 'site' ? 'sites.json' : 'docs.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  async function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0]
+    if (!f) return
+    setFile(f)
+    const res = type === 'site' ? await importSites(f, true) : await importDocs(f, true)
+    setPreview(res.items)
+    setErrors(res.errors)
+  }
+
+  async function onImport() {
+    if (!file) return
+    const res = type === 'site' ? await importSites(file) : await importDocs(file)
+    setErrors(res.errors)
+    if (res.errors.length === 0) {
+      setFile(null)
+      setPreview([])
+      onClose()
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="导入/导出" footer={
+      <>
+        <button className="h-9 px-4 rounded-xl border border-gray-300 bg-gray-100 text-sm text-gray-800 shadow-sm hover:bg-gray-200" onClick={onClose}>取消</button>
+        <button disabled={!file || errors.length>0} className="h-9 px-4 rounded-xl border border-blue-600 bg-blue-600 text-sm text-white shadow-sm disabled:opacity-50" onClick={onImport}>导入</button>
+      </>
+    }>
+      <section className="space-y-2">
+        <div className="font-medium">导出</div>
+        <div className="flex gap-2">
+          <button className="h-8 px-3 rounded-lg border border-gray-300 bg-white hover:bg-gray-50" onClick={() => handleExport('site')}>导出网站</button>
+          <button className="h-8 px-3 rounded-lg border border-gray-300 bg-white hover:bg-gray-50" onClick={() => handleExport('doc')}>导出文档</button>
+        </div>
+      </section>
+      <section className="space-y-2">
+        <div className="font-medium">导入</div>
+        <div className="flex items-center gap-2">
+          <select className="border rounded px-2 py-1" value={type} onChange={e => setType(e.target.value as any)}>
+            <option value="site">网站</option>
+            <option value="doc">文档</option>
+          </select>
+          <input type="file" accept=".json,.csv" onChange={onFileChange} />
+        </div>
+        {errors.map((err, idx) => (
+          <div key={idx} className="text-xs text-red-600">{err}</div>
+        ))}
+        {preview.length > 0 && (
+          <div className="max-h-40 overflow-auto border rounded">
+            <table className="min-w-full text-xs">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="px-2 py-1 text-left">标题</th>
+                  <th className="px-2 py-1 text-left">{type === 'site' ? 'URL' : '路径'}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.map((p, i) => (
+                  <tr key={i} className="odd:bg-white even:bg-gray-50">
+                    <td className="px-2 py-1 truncate">{p.title}</td>
+                    <td className="px-2 py-1 truncate">{type === 'site' ? p.url : p.path}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </Modal>
+  )
+}

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -5,7 +5,8 @@ import { useItems } from '../store/useItems'
 import Input from './ui/Input'
 import Modal from './ui/Modal'
 import { Plus, Upload, Download, Lock, Unlock, Star } from 'lucide-react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import ImportExportModal from './ImportExportModal'
 import { useAuth } from '../store/useAuth'
 import { parseTokens } from './TokenFilter'
 import clsx from 'clsx'
@@ -27,6 +28,7 @@ export default function Topbar() {
   const [mpw, setMpw] = useState('')
   const [open, setOpen] = useState(false)
   const [activeIdx, setActiveIdx] = useState(0)
+  const [openImport, setOpenImport] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
 
   const { unlocked, unlock, lock } = useAuth()
@@ -168,8 +170,8 @@ export default function Topbar() {
               ? <IconButton onClick={lock} srLabel="锁定"><Lock className="w-4 h-4" /></IconButton>
               : <IconButton onClick={() => setOpenUnlock(true)} srLabel="解锁"><Unlock className="w-4 h-4" /></IconButton>
             }
-            <Link to="/settings"><IconButton srLabel="导入"><Upload className="w-4 h-4" /></IconButton></Link>
-            <IconButton srLabel="导出"><Download className="w-4 h-4" /></IconButton>
+            <IconButton onClick={() => setOpenImport(true)} srLabel="导入"><Upload className="w-4 h-4" /></IconButton>
+            <IconButton onClick={() => setOpenImport(true)} srLabel="导出"><Download className="w-4 h-4" /></IconButton>
           </div>
         </div>
 
@@ -259,6 +261,8 @@ export default function Topbar() {
           </div>
         </div>
       </Modal>
+
+      <ImportExportModal open={openImport} onClose={() => setOpenImport(false)} />
 
       <CommandK />
     </>

--- a/src/store/useItems.test.ts
+++ b/src/store/useItems.test.ts
@@ -33,6 +33,26 @@ describe('items import/export', () => {
     expect(useItems.getState().items.length).toBe(1)
     expect(useItems.getState().items[0].title).toBe('Doc')
   })
+
+  it('imports sites from csv with field mapping', async () => {
+    const { importSites } = useItems.getState()
+    const csv = 'name,link,desc\nExample,https://example.com,hello'
+    const file: any = { text: async () => csv }
+    await importSites(file)
+    const items = useItems.getState().items
+    expect(items.length).toBe(1)
+    expect((items[0] as any).url).toBe('https://example.com')
+  })
+
+  it('imports docs from csv with field mapping', async () => {
+    const { importDocs } = useItems.getState()
+    const csv = 'name,path\nDoc,/a'
+    const file: any = { text: async () => csv }
+    await importDocs(file)
+    const items = useItems.getState().items
+    expect(items.length).toBe(1)
+    expect((items[0] as any).path).toBe('/a')
+  })
 })
 
 describe('toggleSelect', () => {

--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -3,6 +3,46 @@ import { db } from '../lib/db'
 import type { AnyItem, SiteItem, PasswordItem, DocItem } from '../types'
 import { nanoid } from 'nanoid'
 
+function parseCsv(text: string): string[][] {
+  const lines = text.trim().split(/\r?\n/).filter(Boolean)
+  return lines.map(line => {
+    const res: string[] = []
+    let cur = ''
+    let inQuotes = false
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i]
+      if (c === '"') {
+        if (inQuotes && line[i + 1] === '"') { cur += '"'; i++ } else { inQuotes = !inQuotes }
+      } else if (c === ',' && !inQuotes) {
+        res.push(cur)
+        cur = ''
+      } else {
+        cur += c
+      }
+    }
+    res.push(cur)
+    return res.map(v => v.trim())
+  })
+}
+
+function mapFields(row: Record<string, string>, type: 'site' | 'doc') {
+  const lc = Object.fromEntries(Object.entries(row).map(([k, v]) => [k.toLowerCase(), v]))
+  if (type === 'site') {
+    return {
+      title: lc['title'] || lc['name'] || '',
+      url: lc['url'] || lc['link'] || lc['href'] || '',
+      description: lc['description'] || lc['desc'] || '',
+      tags: Array.isArray(lc['tags']) ? lc['tags'].join(',') : lc['tags'] || lc['tag'] || ''
+    }
+  }
+  return {
+    title: lc['title'] || lc['name'] || '',
+    path: lc['path'] || lc['url'] || lc['link'] || '',
+    source: lc['source'] || 'local',
+    tags: Array.isArray(lc['tags']) ? lc['tags'].join(',') : lc['tags'] || lc['tag'] || ''
+  }
+}
+
 type Filters = { type?: 'site'|'password'|'doc'; tags?: string[] }
 type Tag = { id: string; name: string; color?: string; parentId?: string }
 
@@ -29,9 +69,9 @@ interface ItemState {
   toggleSelect: (id: string, rangeWith?: string | null) => void
 
   exportSites: () => Promise<Blob>
-  importSites: (file: File) => Promise<void>
+  importSites: (file: File, dryRun?: boolean) => Promise<{ items: SiteItem[]; errors: string[] }>
   exportDocs: () => Promise<Blob>
-  importDocs: (file: File) => Promise<void>
+  importDocs: (file: File, dryRun?: boolean) => Promise<{ items: DocItem[]; errors: string[] }>
 }
 
 export const useItems = create<ItemState>((set, get) => ({
@@ -140,11 +180,42 @@ export const useItems = create<ItemState>((set, get) => ({
     return new Blob([JSON.stringify(items, null, 2)], { type: 'application/json' })
   },
 
-  async importSites(file) {
+  async importSites(file, dryRun = false) {
     const text = await file.text()
-    const data = JSON.parse(text) as SiteItem[]
-    if (Array.isArray(data)) await db.items.bulkPut(data.map(it => ({ ...it, type: 'site' })))
-    await get().load()
+    const { items } = get()
+    const sites: SiteItem[] = []
+    const errors: string[] = []
+    try {
+      if (/^\s*[\[{]/.test(text)) {
+        const data = JSON.parse(text)
+        if (Array.isArray(data)) {
+          data.forEach((d: any, idx) => {
+            const m = mapFields(d, 'site')
+            const now = Date.now()
+            sites.push({ id: nanoid(), type: 'site', title: m.title, url: m.url, description: m.description, tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='site').length) + idx + 1 })
+          })
+        }
+      } else {
+        const rows = parseCsv(text)
+        if (rows.length > 1) {
+          const header = rows[0].map(h => h.toLowerCase())
+          for (let i = 1; i < rows.length; i++) {
+            const row: Record<string,string> = {}
+            header.forEach((h, idx) => { row[h] = rows[i][idx] })
+            const m = mapFields(row, 'site')
+            const now = Date.now()
+            sites.push({ id: nanoid(), type: 'site', title: m.title, url: m.url, description: m.description, tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='site').length) + i })
+          }
+        }
+      }
+    } catch (e: any) {
+      errors.push(e.message)
+    }
+    if (!dryRun && sites.length) {
+      await db.items.bulkPut(sites)
+      await get().load()
+    }
+    return { items: sites, errors }
   },
 
   async exportDocs() {
@@ -152,10 +223,41 @@ export const useItems = create<ItemState>((set, get) => ({
     return new Blob([JSON.stringify(items, null, 2)], { type: 'application/json' })
   },
 
-  async importDocs(file) {
+  async importDocs(file, dryRun = false) {
     const text = await file.text()
-    const data = JSON.parse(text) as DocItem[]
-    if (Array.isArray(data)) await db.items.bulkPut(data.map(it => ({ ...it, type: 'doc' })))
-    await get().load()
+    const { items } = get()
+    const docs: DocItem[] = []
+    const errors: string[] = []
+    try {
+      if (/^\s*[\[{]/.test(text)) {
+        const data = JSON.parse(text)
+        if (Array.isArray(data)) {
+          data.forEach((d: any, idx) => {
+            const m = mapFields(d, 'doc')
+            const now = Date.now()
+            docs.push({ id: nanoid(), type: 'doc', title: m.title, path: m.path, source: (m.source as any) || 'local', description: '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='doc').length) + idx + 1 })
+          })
+        }
+      } else {
+        const rows = parseCsv(text)
+        if (rows.length > 1) {
+          const header = rows[0].map(h => h.toLowerCase())
+          for (let i = 1; i < rows.length; i++) {
+            const row: Record<string,string> = {}
+            header.forEach((h, idx) => { row[h] = rows[i][idx] })
+            const m = mapFields(row, 'doc')
+            const now = Date.now()
+            docs.push({ id: nanoid(), type: 'doc', title: m.title, path: m.path, source: (m.source as any) || 'local', description: '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='doc').length) + i })
+          }
+        }
+      }
+    } catch (e: any) {
+      errors.push(e.message)
+    }
+    if (!dryRun && docs.length) {
+      await db.items.bulkPut(docs)
+      await get().load()
+    }
+    return { items: docs, errors }
   }
 }))


### PR DESCRIPTION
## Summary
- add import/export modal and wire buttons in top bar
- support JSON/CSV field matching when importing sites and docs
- test CSV import auto mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc045e7a68833183adf84d8088c150