### PR TITLE
refactor: auto assign tag colors

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,19 @@
 import { NavLink } from 'react-router-dom'
 import { useItems } from '../store/useItems'
-import Badge from './ui/Badge'
+import { TAG_COLORS, type TagColor } from '../types'
 import { useSettings } from '../store/useSettings'
+
+const palette: Record<TagColor, string> = {
+  gray: '#9ca3af',
+  blue: '#60a5fa',
+  green: '#34d399',
+  red: '#f87171',
+  yellow: '#facc15',
+  purple: '#a78bfa',
+  pink: '#f472b6',
+  orange: '#fb923c',
+  cyan: '#22d3ee',
+}
 
 export default function Sidebar() {
   const tags = useItems(s => s.tags)
@@ -22,7 +34,15 @@ export default function Sidebar() {
       <div>
         <div className="text-xs text-gray-500 px-2 mb-1">{text.tags}</div>
         <div className="flex flex-wrap gap-1 px-2">
-          {tags.map(t => <Badge key={t.id} color={t.color}>{t.name}</Badge>)}
+          {tags.map((t, idx) => {
+            const color = TAG_COLORS[idx % TAG_COLORS.length]
+            return (
+              <span key={t.id} className="flex items-center gap-1 px-2 py-0.5 rounded border text-xs">
+                <span className="w-2 h-2 rounded-full" style={{ background: palette[color] }} />
+                {t.name}
+              </span>
+            )
+          })}
           {tags.length === 0 && <div className="text-xs text-gray-400">{text.none}</div>}
         </div>
       </div>

--- a/src/components/TagPicker.tsx
+++ b/src/components/TagPicker.tsx
@@ -2,25 +2,11 @@ import IconButton from './ui/IconButton'
 import React, { useState } from 'react'
 import { useItems } from '../store/useItems'
 import Input from './ui/Input'
-import clsx from 'clsx'
-import { TAG_COLORS, type TagColor } from '../types'
+import { X, Tag as TagIcon } from 'lucide-react'
 
 export default function TagPicker({ value, onChange }: { value: string[]; onChange: (tags: string[]) => void }) {
   const { tags, addTag, removeTag } = useItems()
   const [name, setName] = useState('')
-  const [color, setColor] = useState<TagColor>('gray')
-
-  const colorBg: Record<TagColor, string> = {
-    gray: 'bg-gray-400',
-    blue: 'bg-blue-400',
-    green: 'bg-green-400',
-    red: 'bg-red-400',
-    yellow: 'bg-yellow-400',
-    purple: 'bg-purple-400',
-    pink: 'bg-pink-400',
-    orange: 'bg-orange-400',
-    cyan: 'bg-cyan-400',
-  }
 
   return (
     <div className="space-y-2">
@@ -65,26 +51,12 @@ export default function TagPicker({ value, onChange }: { value: string[]; onChan
           onChange={e => setName(e.target.value)}
           className="w-40"
         />
-        <div className="flex items-center gap-1">
-          {TAG_COLORS.map(c => (
-            <button
-              key={c}
-              type="button"
-              onClick={() => setColor(c)}
-              className={clsx(
-                'w-5 h-5 rounded-full border-2',
-                color === c ? 'border-black' : 'border-transparent',
-                colorBg[c],
-              )}
-            />
-          ))}
-        </div>
         <IconButton
           size="sm"
           srLabel="新建标签"
           onClick={() => {
             if (!name.trim()) return
-            addTag({ name, color })
+            addTag({ name })
             setName('')
           }}
         >

--- a/src/components/TagRow.tsx
+++ b/src/components/TagRow.tsx
@@ -3,7 +3,7 @@ import { useItems } from '../store/useItems'
 import clsx from 'clsx'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { X } from 'lucide-react'
-import type { TagColor } from '../types'
+import { TAG_COLORS, type TagColor } from '../types'
 
 export default function TagRow() {
   const { items, tags, removeTag } = useItems()
@@ -26,13 +26,20 @@ export default function TagRow() {
 
   return (
     <div className="flex items-center gap-2 overflow-x-auto no-scrollbar py-2">
-      <TagChip id="all" name="全部" color="gray" active={active === 'all'} count={counts.all || 0} onClick={() => goto('all')} />
-      {tags.map(t => (
+      <TagChip
+        id="all"
+        name="全部"
+        color="gray"
+        active={active === 'all'}
+        count={counts.all || 0}
+        onClick={() => goto('all')}
+      />
+      {tags.map((t, idx) => (
         <TagChip
           key={t.id}
           id={t.id}
           name={t.name}
-          color={t.color || 'gray'}
+          color={TAG_COLORS[idx % TAG_COLORS.length]}
           active={active === t.id}
           count={counts[t.id] || 0}
           onClick={() => goto(t.id)}
@@ -42,8 +49,37 @@ export default function TagRow() {
     </div>
   )
 }
+
+export function TagChip({
+  id,
+  name,
+  color,
+  active,
+  count,
+  onClick,
+  onDelete,
+}: {
+  id: string
+  name: string
+  color: TagColor
+  active: boolean
+  count: number
+  onClick: () => void
+  onDelete?: () => void
+}) {
+  const palette: Record<TagColor, string> = {
+    gray: '#9ca3af',
+    blue: '#60a5fa',
+    green: '#34d399',
+    red: '#f87171',
+    yellow: '#facc15',
+    purple: '#a78bfa',
+    pink: '#f472b6',
+    orange: '#fb923c',
+    cyan: '#22d3ee',
   }
-  const dot = palette[color] || palette.gray
+  const dot = palette[color]
+
   return (
     <div className="relative group">
       <button

--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -63,7 +63,7 @@ interface ItemState {
   remove: (id: string) => Promise<void>
   removeMany: (ids: string[]) => Promise<void>
 
-  addTag: (p: {name: string; color?: TagColor; parentId?: string}) => Promise<string>
+  addTag: (p: { name: string; parentId?: string }) => Promise<string>
   removeTag: (id: string) => Promise<void>
   setFilters: (f: Partial<Filters>) => void
   clearSelection: () => void
@@ -144,7 +144,7 @@ export const useItems = create<ItemState>((set, get) => ({
   async addTag(p) {
     const id = nanoid()
     const { tags } = get()
-    const color = p.color ?? TAG_COLORS[tags.length % TAG_COLORS.length]
+    const color = TAG_COLORS[tags.length % TAG_COLORS.length] as TagColor
     await db.tags.put({ id, ...p, color })
     await get().load()
     return id

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,18 +40,7 @@ export interface DocItem extends BaseItem {
 
 export type AnyItem = SiteItem | PasswordItem | DocItem
 
-export type TagColor =
-  | 'gray'
-  | 'blue'
-  | 'green'
-  | 'red'
-  | 'yellow'
-  | 'purple'
-  | 'pink'
-  | 'orange'
-  | 'cyan'
-
-export const TAG_COLORS: TagColor[] = [
+export const TAG_COLORS = [
   'gray',
   'blue',
   'green',
@@ -61,11 +50,13 @@ export const TAG_COLORS: TagColor[] = [
   'pink',
   'orange',
   'cyan',
-]
+] as const
+
+export type TagColor = (typeof TAG_COLORS)[number]
 
 export interface Tag {
   id: string
   name: string
-  color: TagColor
+  color?: TagColor
   parentId?: string
 }


### PR DESCRIPTION
## Summary
- auto-assign tag colors and make tag color optional
- simplify tag creation UI and remove manual color selection
- render tags with internally assigned color dots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcf7337af08331a21161ad0057a7ea