### PR TITLE
feat: improve tag deletion controls

### DIFF
--- a/src/components/TagPicker.tsx
+++ b/src/components/TagPicker.tsx
@@ -29,7 +29,7 @@ export default function TagPicker({ value, onChange }: { value: string[]; onChan
               type="button"
               title="删除标签"
               aria-label="删除标签"
-              className="text-gray-400 hover:text-red-600"
+              className="w-4 h-4 flex items-center justify-center text-gray-400 hover:text-red-600"
               onClick={async () => {
                 if (confirm(`确认删除标签 "${t.name}"?`)) {
                   await removeTag(t.id)

--- a/src/components/TagRow.tsx
+++ b/src/components/TagRow.tsx
@@ -101,7 +101,7 @@ export function TagChip({
             e.stopPropagation()
             onDelete()
           }}
-          className="absolute -top-1 -right-1 hidden group-hover:block bg-surface rounded-full text-muted hover:text-red-600"
+          className="absolute -top-1 -right-1 w-4 h-4 flex items-center justify-center rounded-full border border-border bg-surface text-muted opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-600"
         >
           <X className="w-3 h-3" />
         </button>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,11 +3,12 @@ import ImportExportModal from '../components/ImportExportModal'
 import { useItems } from '../store/useItems'
 import { useSettings } from '../store/useSettings'
 import { useTranslation } from '../lib/i18n'
+import { X } from 'lucide-react'
 
 export default function Settings() {
   const { language, setLanguage } = useSettings()
   const { t } = useTranslation()
-  const { exportSites, exportDocs } = useItems()
+  const { exportSites, exportDocs, tags, removeTag } = useItems()
   const [importType, setImportType] = useState<'site' | 'doc' | null>(null)
 
   async function handleExport(kind: 'site' | 'doc') {
@@ -40,6 +41,30 @@ export default function Settings() {
           <button className="h-8 px-3 rounded-lg border border-gray-300 bg-white hover:bg-gray-50" onClick={() => setImportType('doc')}>导入文档</button>
           <button className="h-8 px-3 rounded-lg border border-gray-300 bg-white hover:bg-gray-50" onClick={() => handleExport('site')}>导出网站</button>
           <button className="h-8 px-3 rounded-lg border border-gray-300 bg-white hover:bg-gray-50" onClick={() => handleExport('doc')}>导出文档</button>
+        </div>
+      </section>
+      <section>
+        <h2 className="text-lg font-medium mb-2">标签管理</h2>
+        <div className="flex flex-wrap gap-2">
+          {tags.map(t => (
+            <span key={t.id} className="flex items-center gap-1 px-2 py-0.5 rounded bg-gray-100">
+              {t.name}
+              <button
+                type="button"
+                title="删除标签"
+                aria-label="删除标签"
+                className="w-4 h-4 flex items-center justify-center text-gray-400 hover:text-red-600"
+                onClick={async () => {
+                  if (confirm(`确认删除标签 "${t.name}"?`)) {
+                    await removeTag(t.id)
+                  }
+                }}
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </span>
+          ))}
+          {tags.length === 0 && <div className="text-xs text-gray-400">暂无标签</div>}
         </div>
       </section>
       <ImportExportModal open={importType !== null} initialType={importType ?? 'site'} onClose={() => setImportType(null)} />


### PR DESCRIPTION
## Summary
- improve TagChip delete button visibility
- keep TagPicker delete icon and call removeTag
- add tag management in settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcfeabc6d88331a6b5a656ceabc91b