### PR TITLE
Fix TypeScript issues and add missing translations

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom'
 import { useItems } from '../store/useItems'
 import { TAG_COLORS, type TagColor } from '../types'
-import { useSettings } from '../store/useSettings'
+import { useTranslation } from '../lib/i18n'
 
 const palette: Record<TagColor, string> = {
   gray: '#9ca3af',
@@ -17,10 +17,7 @@ const palette: Record<TagColor, string> = {
 
 export default function Sidebar() {
   const tags = useItems(s => s.tags)
-  const language = useSettings(s => s.language)
-  const text = language === 'en'
-    ? { dashboard: 'Dashboard', sites: 'Sites', vault: 'Vault', docs: 'Docs', chat: 'Chat', settings: 'Settings', tags: 'Tags', none: '(no tags)' }
-    : { dashboard: '工作台', sites: '网站', vault: '密码库', docs: '文档', chat: '对话', settings: '设置', tags: '标签', none: '（暂无标签）' }
+  const t = useTranslation()
   const linkClass =
     ({ isActive }: { isActive: boolean }) =>
       'block px-2 py-1 rounded hover:bg-gray-50 border-l-4 ' +
@@ -29,10 +26,16 @@ export default function Sidebar() {
   return (
     <aside className="max-w-screen-lg mx-auto px-6 py-4 text-sm space-y-3 rounded-2xl shadow-sm border-r bg-white">
       <nav className="space-y-1">
+        <NavLink to="/" end className={linkClass}>{t('dashboard')}</NavLink>
+        <NavLink to="/sites" className={linkClass}>{t('sites')}</NavLink>
+        <NavLink to="/vault" className={linkClass}>{t('vault')}</NavLink>
+        <NavLink to="/docs" className={linkClass}>{t('docs')}</NavLink>
+        <NavLink to="/chat" className={linkClass}>{t('chat')}</NavLink>
+        <NavLink to="/settings" className={linkClass}>{t('settings')}</NavLink>
       </nav>
 
       <div>
-        <div className="text-xs text-gray-500 px-2 mb-1">{text.tags}</div>
+        <div className="text-xs text-gray-500 px-2 mb-1">{t('tags')}</div>
         <div className="flex flex-wrap gap-1 px-2">
           {tags.map((t, idx) => {
             const color = TAG_COLORS[idx % TAG_COLORS.length]
@@ -43,7 +46,7 @@ export default function Sidebar() {
               </span>
             )
           })}
-          {tags.length === 0 && <div className="text-xs text-gray-400">{text.none}</div>}
+          {tags.length === 0 && <div className="text-xs text-gray-400">{t('noTags')}</div>}
         </div>
       </div>
     </aside>

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -9,6 +9,7 @@ import { parseTokens } from './TokenFilter'
 import clsx from 'clsx'
 import { useNavigate } from 'react-router-dom'
 import { Plus, Lock, Unlock, Star, User, LogOut } from 'lucide-react'
+import ImportExportModal from './ImportExportModal'
 
 type RowType = 'site'|'password'|'doc'
 type Row = {

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -8,7 +8,7 @@ async function deriveKey(masterPassword: string, salt: Uint8Array) {
   )
   return crypto.subtle.deriveKey({
     name: 'PBKDF2',
-    salt,
+    salt: salt.buffer as ArrayBuffer,
     iterations: 200_000,
     hash: 'SHA-256'
   }, keyMaterial, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'])

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -9,6 +9,12 @@ const dict = {
     importExport: '导入 / 导出',
     sites: '站点',
     docs: '文档',
+    vault: '保险库',
+    dashboard: '工作台',
+    chat: '对话',
+    settings: '设置',
+    tags: '标签',
+    noTags: '（暂无标签）',
     view: '自定义视图',
     default: '默认',
     list: '列表',
@@ -17,7 +23,8 @@ const dict = {
     save: '保存',
     cancel: '取消',
     chinese: '中文',
-    english: 'English'
+    english: 'English',
+    comingSoon: '敬请期待'
   },
   en: {
     search: 'Search…',
@@ -27,6 +34,12 @@ const dict = {
     importExport: 'Import / Export',
     sites: 'Sites',
     docs: 'Docs',
+    vault: 'Vault',
+    dashboard: 'Dashboard',
+    chat: 'Chat',
+    settings: 'Settings',
+    tags: 'Tags',
+    noTags: '(no tags)',
     view: 'Default View',
     default: 'Default',
     list: 'List',
@@ -35,14 +48,16 @@ const dict = {
     save: 'Save',
     cancel: 'Cancel',
     chinese: 'Chinese',
-    english: 'English'
+    english: 'English',
+    comingSoon: 'Coming soon'
   }
 }
 
 export type TKey = keyof typeof dict['zh']
 
 export function translate(lang: Language, key: TKey): string {
-  return dict[lang][key]
+  const d = dict[lang as keyof typeof dict] ?? dict.en
+  return d[key] ?? dict.en[key] ?? key
 }
 
 export function useTranslation() {

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,8 +1,17 @@
 export async function chatWithLLM(prompt: string): Promise<string> {
-  const url = import.meta.env.VITE_LLM_API_URL
-  const key = import.meta.env.VITE_LLM_API_KEY
+  const url = (import.meta as any).env?.VITE_LLM_API_URL
+  const key = (import.meta as any).env?.VITE_LLM_API_KEY
 
   if (!url) throw new Error('VITE_LLM_API_URL is not set')
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(key ? { Authorization: `Bearer ${key}` } : {})
+    },
+    body: JSON.stringify({ prompt })
+  })
 
   const data = await res.json().catch(() => ({}))
   return data.reply ?? data.message ?? ''

--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -12,6 +12,7 @@ import { useSearchParams } from 'react-router-dom'
 import { Trash2, XCircle } from 'lucide-react'
 import FixedUrl from '../components/FixedUrl'
 import { useSettings } from '../store/useSettings'
+import { useTranslation } from '../lib/i18n'
 
 function Field({ label, children }: { label: string; children: any }) {
   return (
@@ -26,6 +27,11 @@ export default function Docs() {
   const { items, tags, load, addDoc, update, removeMany, selection, toggleSelect, clearSelection } = useItems()
   const [params] = useSearchParams()
   const activeTag = params.get('tag')
+  const t = useTranslation()
+
+  const [q] = useState('')
+  const viewMode = useSettings(s => s.viewMode)
+  const [view, setView] = useState<'table' | 'card'>(viewMode === 'card' ? 'card' : 'table')
 
   // 新建
   const [openNew, setOpenNew] = useState(false)
@@ -38,12 +44,10 @@ export default function Docs() {
   const [edit, setEdit] = useState<DocItem | null>(null)
 
   useEffect(() => { load() }, [])
-  useEffect(() => { if (viewMode !== 'default') setView(viewMode) }, [viewMode])
-
   useEffect(() => {
-    if (prefView === 'card') setView('card')
-    else if (prefView === 'list') setView('table')
-  }, [prefView])
+    if (viewMode === 'card') setView('card')
+    else if (viewMode === 'list') setView('table')
+  }, [viewMode])
 
   // 顶部搜索：定位+高亮
   useEffect(() => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import { X } from 'lucide-react'
 
 export default function Settings() {
   const { language, setLanguage } = useSettings()
-  const { t } = useTranslation()
+  const t = useTranslation()
   const { exportSites, exportDocs, tags, removeTag } = useItems()
   const [importType, setImportType] = useState<'site' | 'doc' | null>(null)
 

--- a/src/pages/Sites.tsx
+++ b/src/pages/Sites.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '../lib/i18n'
 
 export default function Sites() {
-  const { t } = useTranslation()
+  const t = useTranslation()
   return (
     <div className="max-w-screen-lg mx-auto p-6 bg-surface text-text rounded-2xl shadow-sm">
       <h1 className="text-lg font-medium mb-2">{t('sites')}</h1>

--- a/src/pages/Vault.tsx
+++ b/src/pages/Vault.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '../lib/i18n'
 
 export default function Vault() {
-  const { t } = useTranslation()
+  const t = useTranslation()
   return (
     <div className="max-w-screen-lg mx-auto p-6 bg-surface text-text rounded-2xl shadow-sm">
       <h1 className="text-lg font-medium mb-2">{t('vault')}</h1>

--- a/src/store/useItems.test.ts
+++ b/src/store/useItems.test.ts
@@ -94,18 +94,18 @@ describe('toggleSelect', () => {
     expect([...sel].sort()).toEqual(docs.map(i => i.id).sort())
   })
 
-  it('selects range of passwords when filtered', async () => {
-    const { addPassword, addSite, setFilters, clearSelection, toggleSelect } = useItems.getState()
-    await addPassword({ title: 'P1', username: '', password: '', url: '', description: '', tags: [] })
-    await new Promise(r => setTimeout(r, 1))
-    await addPassword({ title: 'P2', username: '', password: '', url: '', description: '', tags: [] })
-    await new Promise(r => setTimeout(r, 1))
-    await addPassword({ title: 'P3', username: '', password: '', url: '', description: '', tags: [] })
-    await addSite({ title: 'S', url: '', description: '', tags: [] })
-    setFilters({ type: 'password' })
-    clearSelection()
-    const pwds = useItems.getState().items.filter(i => i.type === 'password')
-    const first = pwds[0].id
+    it('selects range of passwords when filtered', async () => {
+      const { addPassword, addSite, setFilters, clearSelection, toggleSelect } = useItems.getState()
+      await addPassword({ title: 'P1', username: '', passwordCipher: '', url: '', description: '', tags: [] })
+      await new Promise(r => setTimeout(r, 1))
+      await addPassword({ title: 'P2', username: '', passwordCipher: '', url: '', description: '', tags: [] })
+      await new Promise(r => setTimeout(r, 1))
+      await addPassword({ title: 'P3', username: '', passwordCipher: '', url: '', description: '', tags: [] })
+      await addSite({ title: 'S', url: '', description: '', tags: [] })
+      setFilters({ type: 'password' })
+      clearSelection()
+      const pwds = useItems.getState().items.filter(i => i.type === 'password')
+      const first = pwds[0].id
     const last = pwds[2].id
     toggleSelect(first)
     toggleSelect(last, first)

--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -93,21 +93,21 @@ export const useItems = create<ItemState>((set, get) => ({
     const id = nanoid()
     const now = Date.now()
     const order = (get().items.filter(i=>i.type==='site') as SiteItem[]).length + 1
-    const item: SiteItem = { id, type: 'site', createdAt: now, updatedAt: now, tags: [], order, ...p }
+    const item: SiteItem = { id, type: 'site', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
     await db.items.put(item); await get().load(); return id
   },
   async addPassword(p) {
     const id = nanoid()
     const now = Date.now()
     const order = (get().items.filter(i=>i.type==='password') as PasswordItem[]).length + 1
-    const item: PasswordItem = { id, type: 'password', createdAt: now, updatedAt: now, tags: [], order, ...p }
+    const item: PasswordItem = { id, type: 'password', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
     await db.items.put(item); await get().load(); return id
   },
   async addDoc(p) {
     const id = nanoid()
     const now = Date.now()
     const order = (get().items.filter(i=>i.type==='doc') as DocItem[]).length + 1
-    const item: DocItem = { id, type: 'doc', createdAt: now, updatedAt: now, tags: [], order, ...p }
+    const item: DocItem = { id, type: 'doc', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
     await db.items.put(item); await get().load(); return id
   },
   async update(id, patch) {
@@ -195,7 +195,7 @@ export const useItems = create<ItemState>((set, get) => ({
           data.forEach((d: any, idx) => {
             const m = mapFields(d, 'site')
             const now = Date.now()
-            sites.push({ id: nanoid(), type: 'site', title: m.title, url: m.url, description: m.description, tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='site').length) + idx + 1 })
+            sites.push({ id: nanoid(), type: 'site', title: m.title || '', url: m.url || '', description: m.description || '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='site').length) + idx + 1 })
           })
         }
       } else {
@@ -207,7 +207,7 @@ export const useItems = create<ItemState>((set, get) => ({
             header.forEach((h, idx) => { row[h] = rows[i][idx] })
             const m = mapFields(row, 'site')
             const now = Date.now()
-            sites.push({ id: nanoid(), type: 'site', title: m.title, url: m.url, description: m.description, tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='site').length) + i })
+            sites.push({ id: nanoid(), type: 'site', title: m.title || '', url: m.url || '', description: m.description || '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='site').length) + i })
           }
         }
       }
@@ -238,7 +238,7 @@ export const useItems = create<ItemState>((set, get) => ({
           data.forEach((d: any, idx) => {
             const m = mapFields(d, 'doc')
             const now = Date.now()
-            docs.push({ id: nanoid(), type: 'doc', title: m.title, path: m.path, source: (m.source as any) || 'local', description: '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='doc').length) + idx + 1 })
+            docs.push({ id: nanoid(), type: 'doc', title: m.title || '', path: m.path || '', source: (m.source as any) || 'local', description: '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='doc').length) + idx + 1 })
           })
         }
       } else {
@@ -250,7 +250,7 @@ export const useItems = create<ItemState>((set, get) => ({
             header.forEach((h, idx) => { row[h] = rows[i][idx] })
             const m = mapFields(row, 'doc')
             const now = Date.now()
-            docs.push({ id: nanoid(), type: 'doc', title: m.title, path: m.path, source: (m.source as any) || 'local', description: '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='doc').length) + i })
+            docs.push({ id: nanoid(), type: 'doc', title: m.title || '', path: m.path || '', source: (m.source as any) || 'local', description: '', tags: (m.tags ? m.tags.split(/[;,]/).map(t=>t.trim()).filter(Boolean) : []), createdAt: now, updatedAt: now, order: (items.filter(i=>i.type==='doc').length) + i })
           }
         }
       }

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -27,8 +27,8 @@ export const useSettings = create<SettingsState>((set) => ({
       const storedLang = localStorage.getItem('language') as Language | null
       const storedView = localStorage.getItem('viewMode') as ViewMode | null
       set({
-        language: storedLang ?? 'zh',
-        viewMode: storedView ?? 'default'
+        language: storedLang === 'en' ? 'en' : 'zh',
+        viewMode: storedView === 'card' || storedView === 'list' ? storedView : 'default'
       })
     } catch {
       /* noop */


### PR DESCRIPTION
## Summary
- add missing translations and wire up useTranslation across pages
- resolve TypeScript compile errors in stores and utilities
- implement LLM chat helper and fix cryptography salt typing
- restore sidebar navigation and use i18n for links and tags
- handle missing translation keys and sanitize stored language

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bd20dda57c8331bc9931b2c2eb8835