### PR TITLE
refactor: use i18n for docs page labels

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -24,7 +24,16 @@ const dict = {
     cancel: '取消',
     chinese: '中文',
     english: 'English',
-    comingSoon: '敬请期待'
+    comingSoon: '敬请期待',
+    title: '标题',
+    pathOrSource: '路径/来源',
+    actions: '操作',
+    edit: '编辑',
+    deleteSelected: '删除所选',
+    clearSelection: '清除选择',
+    open: '打开',
+    newDoc: '新建文档',
+    editDoc: '编辑文档'
   },
   en: {
     search: 'Search…',
@@ -49,7 +58,16 @@ const dict = {
     cancel: 'Cancel',
     chinese: 'Chinese',
     english: 'English',
-    comingSoon: 'Coming soon'
+    comingSoon: 'Coming soon',
+    title: 'Title',
+    pathOrSource: 'Path/Source',
+    actions: 'Actions',
+    edit: 'Edit',
+    deleteSelected: 'Delete Selected',
+    clearSelection: 'Clear Selection',
+    open: 'Open',
+    newDoc: 'New Document',
+    editDoc: 'Edit Document'
   }
 }
 

--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -107,10 +107,10 @@ export default function Docs() {
         <thead className="bg-surface-hover">
           <tr className="text-left text-muted">
             <th className="px-3 py-2"></th>
-            <th className="px-3 py-2">标题</th>
-            <th className="px-3 py-2">标签</th>
-            <th className="px-3 py-2">路径/来源</th>
-            <th className="px-3 py-2 text-right pr-4 md:pr-6">操作</th>
+            <th className="px-3 py-2">{t('title')}</th>
+            <th className="px-3 py-2">{t('tags')}</th>
+            <th className="px-3 py-2">{t('pathOrSource')}</th>
+            <th className="px-3 py-2 text-right pr-4 md:pr-6">{t('actions')}</th>
           </tr>
         </thead>
         <tbody>
@@ -127,7 +127,7 @@ export default function Docs() {
               <td className="px-3 py-2 pr-4 md:pr-6">
                 <div className="flex items-center gap-2 justify-end">
                   <Button size="sm" variant="secondary" className="px-3" onClick={() => { setEdit(it); setOpenEdit(true) }}>
-                    编辑
+                    {t('edit')}
                   </Button>
                 </div>
               </td>
@@ -148,7 +148,7 @@ export default function Docs() {
           {it.description && <div className="text-xs text-muted mt-1 line-clamp-2">{it.description}</div>}
           <div className="mt-2 flex items-center gap-2 justify-end">
             <Button size="sm" variant="secondary" className="px-3" onClick={() => { setEdit(it); setOpenEdit(true) }}>
-              编辑
+              {t('edit')}
             </Button>
           </div>
         </div>
@@ -163,10 +163,10 @@ export default function Docs() {
           <TagRow />
           {selection.size > 0 && (
             <div className="mt-2 flex items-center gap-2">
-              <IconButton size="sm" srLabel="删除所选" onClick={() => { removeMany(Array.from(selection)); clearSelection() }}>
+              <IconButton size="sm" srLabel={t('deleteSelected')} onClick={() => { removeMany(Array.from(selection)); clearSelection() }}>
                 <Trash2 className="w-4 h-4" />
               </IconButton>
-              <IconButton size="sm" srLabel="清除选择" onClick={clearSelection}>
+              <IconButton size="sm" srLabel={t('clearSelection')} onClick={clearSelection}>
                 <XCircle className="w-4 h-4" />
               </IconButton>
             </div>
@@ -185,7 +185,7 @@ export default function Docs() {
       <Modal
         open={openNew}
         onClose={() => setOpenNew(false)}
-        title="新建文档"
+        title={t('newDoc')}
         footer={
           <>
             <Button variant="secondary" onClick={() => setOpenNew(false)}>
@@ -213,7 +213,7 @@ export default function Docs() {
       <Modal
         open={openEdit}
         onClose={() => setOpenEdit(false)}
-        title="编辑文档"
+        title={t('editDoc')}
         footer={
           <>
             {edit?.path && /^https?:\/\//i.test(edit.path) && (
@@ -223,7 +223,7 @@ export default function Docs() {
                 target="_blank"
                 rel="noreferrer"
               >
-                打开
+                {t('open')}
               </a>
             )}
             <Button variant="secondary" onClick={() => setOpenEdit(false)}>


### PR DESCRIPTION
## Summary
- use translation keys for Docs page table headers, action buttons, and modal titles
- add zh/en entries for new labels in i18n dictionary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd412e9d3c833184c6233a76174d6e