### PR TITLE
feat: add useClickOutside hook

### DIFF
--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,5 +1,6 @@
 import IconButton from './ui/IconButton'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useClickOutside } from '../hooks/useClickOutside'
 import CommandK from './CommandK'
 import { useItems } from '../store/useItems'
 import Input from './ui/Input'
@@ -107,23 +108,8 @@ export default function Topbar() {
   useEffect(() => { setActiveIdx(0) }, [q])
   useEffect(() => { setOpen(q.trim().length > 0) }, [q])
 
-  useEffect(() => {
-    function onClickOutside(e: MouseEvent) {
-      if (!listRef.current) return
-      if (!listRef.current.contains(e.target as any)) setOpen(false)
-    }
-    document.addEventListener('mousedown', onClickOutside)
-    return () => document.removeEventListener('mousedown', onClickOutside)
-  }, [])
-
-  useEffect(() => {
-    function onClickOutside(e: MouseEvent) {
-      if (!userRef.current) return
-      if (!userRef.current.contains(e.target as any)) setOpenUser(false)
-    }
-    document.addEventListener('mousedown', onClickOutside)
-    return () => document.removeEventListener('mousedown', onClickOutside)
-  }, [])
+  useClickOutside(listRef, () => setOpen(false))
+  useClickOutside(userRef, () => setOpenUser(false))
 
   // 允许业务页打开解锁框
   useEffect(() => {

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+
+export function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T>,
+  handler: (e: MouseEvent) => void
+) {
+  useEffect(() => {
+    function listener(e: MouseEvent) {
+      const el = ref.current
+      if (!el || el.contains(e.target as Node)) return
+      handler(e)
+    }
+    document.addEventListener('mousedown', listener)
+    return () => document.removeEventListener('mousedown', listener)
+  }, [ref, handler])
+}


### PR DESCRIPTION
## Summary
- add reusable `useClickOutside` hook
- use `useClickOutside` in Topbar for search results and user menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd412ed940833181fefa6d92e8034a