### PR TITLE
refactor: stabilize NavLink class callback

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useItems } from '../store/useItems'
 import { TAG_COLORS, type TagColor } from '../types'
@@ -18,10 +19,12 @@ const palette: Record<TagColor, string> = {
 export default function Sidebar() {
   const tags = useItems(s => s.tags)
   const t = useTranslation()
-  const linkClass =
+  const linkClass = useCallback(
     ({ isActive }: { isActive: boolean }) =>
       'block px-2 py-1 rounded hover:bg-gray-50 border-l-4 ' +
-      (isActive ? 'bg-blue-50 text-blue-700 border-blue-600' : 'border-transparent')
+      (isActive ? 'bg-blue-50 text-blue-700 border-blue-600' : 'border-transparent'),
+    [],
+  )
 
   return (
     <aside className="max-w-screen-lg mx-auto px-6 py-4 text-sm space-y-3 rounded-2xl shadow-sm border-r bg-white">


### PR DESCRIPTION
## Summary
- make NavLink `className` callback stable with `useCallback` to preserve active styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd413205f08331a596d0ee10aa7a4a