### PR TITLE
refactor: memoize sidebar link class

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ const palette: Record<TagColor, string> = {
 export default function Sidebar() {
   const tags = useItems(s => s.tags)
   const t = useTranslation()
+  const linkClass = useCallback(
     ({ isActive }: { isActive: boolean }) =>
       'block px-2 py-1 rounded hover:bg-gray-50 border-l-4 ' +
       (isActive ? 'bg-blue-50 text-blue-700 border-blue-600' : 'border-transparent'),


### PR DESCRIPTION
## Summary
- memoize sidebar link class with useCallback

## Testing
- `npm test` *(fails: Unexpected "export" in src/store/useItems.ts)*
- `npx tsc --noEmit` *(fails: Expression expected in Topbar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bd56e5df148331b63d1367d2e8730c