### PR TITLE
fix doc field mapping in useItems

### DIFF
--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -52,6 +52,24 @@ function mapFields(row: Record<string, unknown>, type: 'site' | 'doc') {
       ? lc['desc']
       : ''
     return { title, url, description, tags }
+  } else {
+    const title = typeof lc['title'] === 'string'
+      ? lc['title']
+      : typeof lc['name'] === 'string'
+      ? lc['name']
+      : ''
+    const path = typeof lc['path'] === 'string'
+      ? lc['path']
+      : typeof lc['url'] === 'string'
+      ? lc['url']
+      : typeof lc['link'] === 'string'
+      ? lc['link']
+      : typeof lc['href'] === 'string'
+      ? lc['href']
+      : ''
+    const source = typeof lc['source'] === 'string' ? lc['source'] : ''
+    return { title, path, source, tags }
+  }
 }
 
 type Filters = { type?: 'site'|'password'|'doc'; tags?: string[] }


### PR DESCRIPTION
## Summary
- close `mapFields` `site` branch with brace
- map `doc` fields and close `mapFields` function

## Testing
- `npm run build` *(fails: Topbar.tsx symbol `t` declared twice)*
- `npm test` *(fails: duplicate symbols in useItems.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5f0a02bc83319b9da1b9b9cd5013