### PR TITLE
Use nextOrder for item insertion order

### DIFF
--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -24,7 +24,6 @@ type Row = {
 
 export default function Topbar() {
   const navigate = useNavigate()
-  const t = useTranslation()
   const [q, setQ] = useState('')
   const [openUnlock, setOpenUnlock] = useState(false)
   const [mpw, setMpw] = useState('')
@@ -245,9 +244,6 @@ export default function Topbar() {
                   </div>
                 )
               })}
-
-              {!looksLikeUrl && groups.flat.length === 0 && (
-              )}
             </div>
           </div>
         )}

--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -52,6 +52,11 @@ function mapFields(row: Record<string, unknown>, type: 'site' | 'doc') {
       ? lc['desc']
       : ''
     return { title, url, description, tags }
+  }
+  const title = typeof lc['title'] === 'string' ? lc['title'] : typeof lc['name'] === 'string' ? lc['name'] : ''
+  const path = typeof lc['path'] === 'string' ? lc['path'] : ''
+  const source = typeof lc['source'] === 'string' ? lc['source'] : typeof lc['origin'] === 'string' ? lc['origin'] : ''
+  return { title, path, source, tags }
 }
 
 type Filters = { type?: 'site'|'password'|'doc'; tags?: string[] }
@@ -110,9 +115,6 @@ export const useItems = create<ItemState>((set, get) => ({
   async addSite(p) {
     const id = nanoid()
     const now = Date.now()
-    const order = (get().items.filter(i=>i.type==='site') as SiteItem[]).length + 1
-    const item: SiteItem = { id, type: 'site', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
-    await db.items.put(item); await get().load(); return id
     const order = get().nextOrder.site
     const item: SiteItem = { id, type: 'site', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
     await db.items.put(item)
@@ -123,9 +125,6 @@ export const useItems = create<ItemState>((set, get) => ({
   async addPassword(p) {
     const id = nanoid()
     const now = Date.now()
-    const order = (get().items.filter(i=>i.type==='password') as PasswordItem[]).length + 1
-    const item: PasswordItem = { id, type: 'password', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
-    await db.items.put(item); await get().load(); return id
     const order = get().nextOrder.password
     const item: PasswordItem = { id, type: 'password', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
     await db.items.put(item)
@@ -136,9 +135,6 @@ export const useItems = create<ItemState>((set, get) => ({
   async addDoc(p) {
     const id = nanoid()
     const now = Date.now()
-    const order = (get().items.filter(i=>i.type==='doc') as DocItem[]).length + 1
-    const item: DocItem = { id, type: 'doc', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
-    await db.items.put(item); await get().load(); return id
     const order = get().nextOrder.doc
     const item: DocItem = { id, type: 'doc', createdAt: now, updatedAt: now, order, ...p, tags: p.tags ?? [] }
     await db.items.put(item)


### PR DESCRIPTION
## Summary
- refactor addSite/addPassword/addDoc to rely on `nextOrder` for consistent ordering
- add doc field mapping and close helper function
- fix Topbar build errors by removing duplicate translation hook

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd5f0a85c083319c82c61d7659766c