### PR TITLE
feat: support password import/export

### DIFF
--- a/src/store/useItems.test.ts
+++ b/src/store/useItems.test.ts
@@ -34,6 +34,18 @@ describe('items import/export', () => {
     expect(useItems.getState().items[0].title).toBe('Doc')
   })
 
+  it('exports and imports passwords', async () => {
+    const { addPassword, exportPasswords, importPasswords, load } = useItems.getState()
+    await addPassword({ title: 'Pw', username: 'u', passwordCipher: 'c', url: 'https://example.com', description: '', tags: [] })
+    const blob = await exportPasswords()
+    const text = await blob.text()
+    await db.items.clear(); await load()
+    const file: any = { text: async () => text }
+    await importPasswords(file)
+    expect(useItems.getState().items.length).toBe(1)
+    expect(useItems.getState().items[0].title).toBe('Pw')
+  })
+
   it('imports sites from csv with field mapping', async () => {
     const { importSites } = useItems.getState()
     const csv = 'name,link,desc\nExample,https://example.com,hello'
@@ -52,6 +64,18 @@ describe('items import/export', () => {
     const items = useItems.getState().items
     expect(items.length).toBe(1)
     expect((items[0] as any).path).toBe('/a')
+  })
+
+  it('imports passwords from csv with field mapping', async () => {
+    const { importPasswords } = useItems.getState()
+    const csv = 'name,username,password,url\nPw,user,cipher,https://example.com'
+    const file: any = { text: async () => csv }
+    await importPasswords(file)
+    const items = useItems.getState().items
+    expect(items.length).toBe(1)
+    const pwd = items[0] as any
+    expect(pwd.username).toBe('user')
+    expect(pwd.passwordCipher).toBe('cipher')
   })
 })
 


### PR DESCRIPTION
## Summary
- allow mapping password fields for CSV/JSON imports
- add `exportPasswords`/`importPasswords` in items store
- test password import/export including CSV mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd628fd33c8331901517e2893d5fd0