### PR TITLE
feat: expand translations for sites and vault

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -2,10 +2,12 @@ import { Edit2, ExternalLink, Trash2 } from 'lucide-react'
 import IconButton from './ui/IconButton'
 import React from 'react'
 import type { SiteItem } from '../types'
+import { useTranslation } from '../lib/i18n'
 
 export function SiteCard({ it, onOpen, onDelete, onEdit }: { it: SiteItem; onOpen:()=>void; onDelete:()=>void; onEdit:()=>void }) {
   const domain = (()=>{ try { return new URL(it.url).hostname } catch { return '' } })()
   const favicon = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=64` : undefined
+  const t = useTranslation()
   return (
     <div className="border rounded p-3 hover:shadow-sm transition">
       <div className="flex items-center gap-2">
@@ -14,13 +16,13 @@ export function SiteCard({ it, onOpen, onDelete, onEdit }: { it: SiteItem; onOpe
       </div>
       <a className="text-xs text-blue-600 truncate block mt-1" href={it.url} target="_blank">{it.url}</a>
       <div className="mt-2 flex gap-2">
-        <IconButton size="sm" onClick={onOpen} srLabel="打开">
+        <IconButton size="sm" onClick={onOpen} srLabel={t('open')}>
           <ExternalLink className="w-4 h-4" />
         </IconButton>
-        <IconButton size="sm" onClick={onEdit} srLabel="编辑">
+        <IconButton size="sm" onClick={onEdit} srLabel={t('edit')}>
           <Edit2 className="w-4 h-4" />
         </IconButton>
-        <IconButton size="sm" onClick={onDelete} srLabel="删除">
+        <IconButton size="sm" onClick={onDelete} srLabel={t('delete')}>
           <Trash2 className="w-4 h-4" />
         </IconButton>
       </div>

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { translate } from './i18n'
+
+describe('translate', () => {
+  it('falls back to English when language is unknown', () => {
+    expect(translate('fr' as any, 'sites')).toBe('Sites')
+  })
+
+  it('returns key when translation is missing', () => {
+    expect(translate('en', 'nonexistent' as any)).toBe('nonexistent')
+  })
+})

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -37,7 +37,20 @@ const dict = {
     locate: '定位',
     noResults: '没有匹配结果',
     enterMaster: '请输入主密码',
-    wrongMaster: '主密码错误'
+    wrongMaster: '主密码错误',
+    site: '站点',
+    doc: '文档',
+    title: '标题',
+    pathOrSource: '路径/来源',
+    actions: '操作',
+    edit: '编辑',
+    delete: '删除',
+    deleteSelected: '删除已选',
+    clearSelection: '清除选择',
+    newDoc: '新建文档',
+    editDoc: '编辑文档',
+    newSite: '新建网站',
+    newPassword: '新建密码'
   },
   en: {
     search: 'Search…',
@@ -75,7 +88,20 @@ const dict = {
     locate: 'Locate',
     noResults: 'No matching results',
     enterMaster: 'Enter master password',
-    wrongMaster: 'Incorrect master password'
+    wrongMaster: 'Incorrect master password',
+    site: 'Site',
+    doc: 'Doc',
+    title: 'Title',
+    pathOrSource: 'Path/Source',
+    actions: 'Actions',
+    edit: 'Edit',
+    delete: 'Delete',
+    deleteSelected: 'Delete selected',
+    clearSelection: 'Clear selection',
+    newDoc: 'New Document',
+    editDoc: 'Edit Document',
+    newSite: 'New Site',
+    newPassword: 'New Password'
   }
 }
 

--- a/src/pages/Sites.tsx
+++ b/src/pages/Sites.tsx
@@ -4,7 +4,12 @@ export default function Sites() {
   const t = useTranslation()
   return (
     <div className="max-w-screen-lg mx-auto p-6 bg-surface text-text rounded-2xl shadow-sm">
-      <h1 className="text-lg font-medium mb-2">{t('sites')}</h1>
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-lg font-medium">{t('sites')}</h1>
+        <button className="h-8 px-3 rounded-lg border border-border bg-surface hover:bg-surface-hover text-sm">
+          {t('newSite')}
+        </button>
+      </div>
       <p className="text-sm text-muted">{t('comingSoon')}</p>
     </div>
   )

--- a/src/pages/Vault.tsx
+++ b/src/pages/Vault.tsx
@@ -4,7 +4,12 @@ export default function Vault() {
   const t = useTranslation()
   return (
     <div className="max-w-screen-lg mx-auto p-6 bg-surface text-text rounded-2xl shadow-sm">
-      <h1 className="text-lg font-medium mb-2">{t('vault')}</h1>
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-lg font-medium">{t('vault')}</h1>
+        <button className="h-8 px-3 rounded-lg border border-border bg-surface hover:bg-surface-hover text-sm">
+          {t('newPassword')}
+        </button>
+      </div>
       <p className="text-sm text-muted">{t('comingSoon')}</p>
     </div>
   )

--- a/src/store/useItems.ts
+++ b/src/store/useItems.ts
@@ -31,24 +31,43 @@ function mapFields(row: Record<string, unknown>, type: 'site' | 'doc') {
   const entries = Object.entries(row).map(([k, v]) => [k.toLowerCase(), v] as [string, unknown])
   const lc: Record<string, unknown> = Object.fromEntries(entries)
   const tags = Array.isArray(lc['tags'])
-    ? lc['tags'].join(',')
+    ? (lc['tags'] as unknown[]).join(',')
     : typeof lc['tags'] === 'string'
     ? lc['tags']
     : typeof lc['tag'] === 'string'
     ? lc['tag']
     : ''
   if (type === 'site') {
-    const title = typeof lc['title'] === 'string' ? lc['title'] : typeof lc['name'] === 'string' ? lc['name'] : ''
-    const path = typeof lc['path'] === 'string' ? lc['path'] : ''
-    const source = typeof lc['source'] === 'string' ? lc['source'] : typeof lc['origin'] === 'string' ? lc['origin'] : ''
-    return { title, path, source, tags }
-    } else {
-      const title = typeof lc['title'] === 'string'
+    const title =
+      typeof lc['title'] === 'string'
         ? lc['title']
         : typeof lc['name'] === 'string'
         ? lc['name']
         : ''
-      const path = typeof lc['path'] === 'string'
+    const url =
+      typeof lc['url'] === 'string'
+        ? lc['url']
+        : typeof lc['link'] === 'string'
+        ? lc['link']
+        : typeof lc['href'] === 'string'
+        ? lc['href']
+        : ''
+    const description =
+      typeof lc['description'] === 'string'
+        ? lc['description']
+        : typeof lc['desc'] === 'string'
+        ? lc['desc']
+        : ''
+    return { title, url, description, tags }
+  } else {
+    const title =
+      typeof lc['title'] === 'string'
+        ? lc['title']
+        : typeof lc['name'] === 'string'
+        ? lc['name']
+        : ''
+    const path =
+      typeof lc['path'] === 'string'
         ? lc['path']
         : typeof lc['url'] === 'string'
         ? lc['url']
@@ -57,10 +76,15 @@ function mapFields(row: Record<string, unknown>, type: 'site' | 'doc') {
         : typeof lc['href'] === 'string'
         ? lc['href']
         : ''
-      const source = typeof lc['source'] === 'string' ? lc['source'] : ''
-      return { title, path, source, tags }
-    }
+    const source =
+      typeof lc['source'] === 'string'
+        ? lc['source']
+        : typeof lc['origin'] === 'string'
+        ? lc['origin']
+        : ''
+    return { title, path, source, tags }
   }
+}
 
 type Filters = { type?: 'site'|'password'|'doc'; tags?: string[] }
 


### PR DESCRIPTION
## Summary
- add new i18n keys for site and vault UIs and fallback tests
- use translations in site card and new Sites/Vault buttons
- fix field mapping for site imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd62909a248331a30acf57c0794234