### PR TITLE
refactor: use cached auth key

### DIFF
--- a/src/store/useItems.test.ts
+++ b/src/store/useItems.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { useItems } from './useItems'
 import { useSettings } from './useSettings'
 import { exec } from '../lib/db'
+import { useAuth } from './useAuth'
 
 beforeEach(async () => {
+  useAuth.setState({ key: new Uint8Array(32) })
   await exec('DELETE FROM items')
   await exec('DELETE FROM tags')
   await exec('DELETE FROM settings')


### PR DESCRIPTION
## Summary
- retrieve encryption key from auth store instead of stronghold helper
- error when master key is missing and use cached key in item operations
- seed auth key in tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c54250db988331ade2c66b001fb849