### PR TITLE
Add touchstart support to useClickOutside and tests

### DIFF
--- a/src/hooks/useClickOutside.test.tsx
+++ b/src/hooks/useClickOutside.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+import { useClickOutside } from './useClickOutside'
+
+function Wrapper({ onClose }: { onClose: () => void }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useClickOutside(ref, onClose)
+  return (
+    <div>
+      <div ref={ref} id="inside" />
+      <div id="outside" />
+    </div>
+  )
+}
+
+describe('useClickOutside', () => {
+  it('calls onClose on touchstart outside', () => {
+    const onClose = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    flushSync(() => {
+      root.render(<Wrapper onClose={onClose} />)
+    })
+
+    const outside = container.querySelector('#outside') as HTMLElement
+    outside.dispatchEvent(new Event('touchstart', { bubbles: true }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    root.unmount()
+
+    // event after unmount should not trigger
+    outside.dispatchEvent(new Event('touchstart', { bubbles: true }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,11 +1,15 @@
 import { useEffect } from 'react'
 export function useClickOutside(ref: React.RefObject<HTMLElement>, onClose: () => void) {
   useEffect(() => {
-    function handle(e: MouseEvent) {
+    function handle(e: MouseEvent | TouchEvent) {
       if (!ref.current) return
       if (!ref.current.contains(e.target as Node)) onClose()
     }
     document.addEventListener('mousedown', handle)
-    return () => document.removeEventListener('mousedown', handle)
+    document.addEventListener('touchstart', handle)
+    return () => {
+      document.removeEventListener('mousedown', handle)
+      document.removeEventListener('touchstart', handle)
+    }
   }, [ref, onClose])
 }


### PR DESCRIPTION
## Summary
- handle touchstart alongside mousedown in useClickOutside
- add unit test verifying touch events close overlays and cleanup works

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c542525d84833193b27ff36b5ac679