### PR TITLE
Fix backup password handling and file opener

### DIFF
--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -41,6 +41,10 @@ export async function deleteFile(path: string) {
   try { await removeFile(path); } catch {}
 }
 
-export async function openFile() {
-  throw new Error('not implemented');
+export async function openFile(path: string) {
+  try {
+    window.open(path);
+  } catch (e) {
+    console.error(e);
+  }
 }


### PR DESCRIPTION
## Summary
- use user-provided password for backup/restore and check auth state
- implement openFile helper accepting path and opening via window

## Testing
- `pnpm test`
- `pnpm exec tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@tauri-apps/api/fs', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a099f30c8331980b0da630d1c9ab