### PR TITLE
Lazy load route pages

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,10 @@ import { useAuth } from './store/useAuth'
 import { migrateIfNeeded } from './lib/migrate'
 import { bootstrap } from './lib/bootstrap'
 
+function LoadingMessage() {
+  return <div style={{ padding: 16 }}>Loading…</div>
+}
+
 function BootGate() {
   const [ready, setReady] = React.useState(false)
 
@@ -32,10 +36,12 @@ function BootGate() {
       })
   }, [])
 
-  if (!ready) return <div style={{ padding: 16 }}>Loading…</div>
+  if (!ready) return <LoadingMessage />
   return (
     <React.StrictMode>
-      <RouterProvider router={router} />
+      <React.Suspense fallback={<LoadingMessage />}>
+        <RouterProvider router={router} />
+      </React.Suspense>
       <ToastHub />
     </React.StrictMode>
   )

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,10 +1,12 @@
+import { lazy } from 'react'
 import { createBrowserRouter } from 'react-router-dom'
-import Dashboard from './pages/Dashboard'
-import Sites from './pages/Sites'
-import Passwords from './pages/Passwords'
-import Docs from './pages/Docs'
-import Settings from './pages/Settings'
 import App from './App'
+
+const Dashboard = lazy(() => import('./pages/Dashboard'))
+const Sites = lazy(() => import('./pages/Sites'))
+const Passwords = lazy(() => import('./pages/Passwords'))
+const Docs = lazy(() => import('./pages/Docs'))
+const Settings = lazy(() => import('./pages/Settings'))
 
 export const router = createBrowserRouter([
   {


### PR DESCRIPTION
## Summary
- lazy-load routed pages via `React.lazy`
- wrap the router in a suspense boundary with a shared loading indicator

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cd1ca2a7bc8331a1903526ccc8e8a9