### PR TITLE
Enable tauri API allowlist

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,5 +10,18 @@
   },
   "bundle": {
     "icon": ["icons/icon.ico", "icons/icon.icns"]
+  },
+  "tauri": {
+    "allowlist": {
+      "fs": {
+        "all": true
+      },
+      "path": {
+        "all": true
+      },
+      "shell": {
+        "all": true
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add the tauri allowlist configuration enabling fs, path, and shell APIs in tauri.conf.json

## Testing
- pnpm tauri dev --help
- pnpm tauri build --help

------
https://chatgpt.com/codex/tasks/task_e_68ce608e60d88331a27f140409bdcd6a