### PR TITLE
Update Vite config for Tauri builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,69 +1,90 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const isTauri = process.env.BUILD_TARGET === 'tauri'
 
-export default defineConfig({
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: ['favicon.svg'],
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,webmanifest,woff2}'],
-        navigateFallback: '/index.html',
-        runtimeCaching: [
-          {
-            urlPattern: ({ url }) => url.pathname.startsWith('/api/'),
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'api-cache',
-              networkTimeoutSeconds: 10,
-              cacheableResponse: {
-                statuses: [0, 200]
-              },
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 5 * 60
-              }
-            }
+const pwaOptions = {
+  registerType: 'autoUpdate',
+  includeAssets: ['favicon.svg'],
+  workbox: {
+    globPatterns: ['**/*.{js,css,html,ico,png,svg,webmanifest,woff2}'],
+    navigateFallback: '/index.html',
+    runtimeCaching: [
+      {
+        urlPattern: ({ url }) => url.pathname.startsWith('/api/'),
+        handler: 'NetworkFirst',
+        options: {
+          cacheName: 'api-cache',
+          networkTimeoutSeconds: 10,
+          cacheableResponse: {
+            statuses: [0, 200]
           },
-          {
-            urlPattern: ({ url }) => url.pathname.endsWith('.json') || url.pathname.startsWith('/data/'),
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: 'data-cache',
-              cacheableResponse: {
-                statuses: [0, 200]
-              },
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60
-              }
-            }
+          expiration: {
+            maxEntries: 50,
+            maxAgeSeconds: 5 * 60
           }
-        ]
+        }
       },
-      manifest: {
-        name: 'PMS Web',
-        short_name: 'PMS',
-        start_url: '/',
-        display: 'standalone',
-        background_color: '#0b0b0f',
-        theme_color: '#0ea5e9',
-        icons: [
-          { src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml' }
-        ]
+      {
+        urlPattern: ({ url }) => url.pathname.endsWith('.json') || url.pathname.startsWith('/data/'),
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'data-cache',
+          cacheableResponse: {
+            statuses: [0, 200]
+          },
+          expiration: {
+            maxEntries: 50,
+            maxAgeSeconds: 60 * 60
+          }
+        }
       }
-    })
-  ],
-  resolve: {
-    alias: {
-      '@tauri-apps/api/fs': path.resolve(__dirname, 'src/tauri-fs-impl.ts'),
-      '@tauri-apps/plugin-stronghold': path.resolve(__dirname, 'src/tauri-stronghold-stub.ts')
+    ]
+  },
+  manifest: {
+    name: 'PMS Web',
+    short_name: 'PMS',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#0b0b0f',
+    theme_color: '#0ea5e9',
+    icons: [
+      { src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml' }
+    ]
+  }
+}
+
+export default defineConfig(async () => {
+  const plugins = [react()]
+
+  if (!isTauri) {
+    try {
+      const { VitePWA } = await import('vite-plugin-pwa')
+      plugins.push(VitePWA(pwaOptions))
+    } catch (error) {
+      console.warn('Failed to load vite-plugin-pwa:', error)
+    }
+  }
+
+  return {
+    plugins,
+    ...(isTauri ? { base: './' } : {}),
+    server: {
+      port: 1420,
+      strictPort: true
+    },
+    preview: {
+      port: 1420,
+      strictPort: true
+    },
+    resolve: {
+      alias: {
+        '@tauri-apps/api/fs': path.resolve(__dirname, 'src/tauri-fs-impl.ts'),
+        '@tauri-apps/plugin-stronghold': path.resolve(__dirname, 'src/tauri-stronghold-stub.ts')
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary
- detect Tauri builds via `process.env.BUILD_TARGET` in the Vite config
- only load the PWA plugin for web builds while keeping existing caching options
- set a relative base path and keep the locked dev ports required by the Tauri runtime

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6ca997888331b33484ab2e9536ed