### PR TITLE
Add idle lock controls

### DIFF
--- a/src/components/FabTools.tsx
+++ b/src/components/FabTools.tsx
@@ -1,0 +1,31 @@
+import { Lock as LockIcon } from 'lucide-react'
+import { IdleLockSelector } from '../features/lock/IdleLock'
+import { useLock } from '../features/lock/LockProvider'
+import { useAuthStore } from '../stores/auth'
+
+export default function FabTools() {
+  const email = useAuthStore(state => state.email)
+  const { lock, locked } = useLock()
+
+  if (!email || locked) {
+    return null
+  }
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3">
+      <div className="pointer-events-auto rounded-2xl border border-white/10 bg-slate-900/80 p-4 text-xs text-slate-200 shadow-lg shadow-slate-950/40 backdrop-blur">
+        <IdleLockSelector />
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          lock()
+        }}
+        className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-white px-4 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-slate-950/40 transition hover:bg-slate-200"
+      >
+        <LockIcon className="h-4 w-4" />
+        立即锁定
+      </button>
+    </div>
+  )
+}

--- a/src/features/lock/LockProvider.tsx
+++ b/src/features/lock/LockProvider.tsx
@@ -1,0 +1,44 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { useAuthStore } from '../../stores/auth'
+
+type LockContextValue = {
+  locked: boolean
+  lock: () => void
+  unlock: () => void
+}
+
+const LockContext = createContext<LockContextValue | undefined>(undefined)
+
+export function LockProvider({ children }: { children: ReactNode }) {
+  const email = useAuthStore(s => s.email)
+  const [locked, setLocked] = useState(false)
+
+  const lock = useCallback(() => {
+    if (!email) return
+    setLocked(true)
+    useAuthStore.setState({ encryptionKey: null })
+  }, [email])
+
+  const unlock = useCallback(() => {
+    setLocked(false)
+  }, [])
+
+  useEffect(() => {
+    if (!email) {
+      setLocked(false)
+    }
+  }, [email])
+
+  const value = useMemo(() => ({ locked, lock, unlock }), [locked, lock, unlock])
+
+  return <LockContext.Provider value={value}>{children}</LockContext.Provider>
+}
+
+export function useLock() {
+  const context = useContext(LockContext)
+  if (!context) {
+    throw new Error('useLock must be used within a LockProvider')
+  }
+  return context
+}

--- a/src/features/lock/LockScreen.tsx
+++ b/src/features/lock/LockScreen.tsx
@@ -1,0 +1,83 @@
+import { FormEvent, useState } from 'react'
+import { useAuthStore } from '../../stores/auth'
+import { useLock } from './LockProvider'
+
+export function LockScreen() {
+  const { locked, unlock } = useLock()
+  const email = useAuthStore(s => s.email)
+  const login = useAuthStore(s => s.login)
+  const logout = useAuthStore(s => s.logout)
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  if (!locked || !email) {
+    return null
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!password.trim()) {
+      setError('请输入密码以解锁')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const result = await login(email, password)
+      if (result.success) {
+        setPassword('')
+        unlock()
+      } else {
+        setError(result.message ?? '解锁失败，请重试')
+      }
+    } catch (error) {
+      console.error('Failed to unlock', error)
+      setError('解锁失败，请重试')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 px-6 py-12">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl border border-white/10 bg-slate-950/80 p-8 shadow-xl shadow-slate-950/40">
+        <div className="space-y-1 text-center">
+          <h2 className="text-2xl font-semibold text-white">已锁定</h2>
+          <p className="text-sm text-slate-300">{email}</p>
+          <p className="text-sm text-slate-400">请输入密码以继续使用应用</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label className="space-y-2 text-sm">
+            <span className="text-slate-200">密码</span>
+            <input
+              type="password"
+              value={password}
+              onChange={event => setPassword(event.target.value)}
+              autoFocus
+              className="w-full rounded-xl border border-white/20 bg-slate-900/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/60 focus:bg-slate-900"
+              placeholder="请输入密码"
+            />
+          </label>
+          {error && <p className="text-sm text-rose-300">{error}</p>}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex w-full items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-900 transition hover:bg-slate-200 disabled:opacity-70"
+          >
+            {submitting ? '解锁中…' : '解锁'}
+          </button>
+        </form>
+        <button
+          type="button"
+          onClick={() => {
+            void logout()
+          }}
+          className="block w-full text-center text-xs text-slate-400 transition hover:text-slate-200"
+        >
+          切换账号
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
+import FabTools from './components/FabTools'
+import IdleLock from './features/lock/IdleLock'
+import { LockProvider } from './features/lock/LockProvider'
+import { LockScreen } from './features/lock/LockScreen'
 
 const rootElement = document.getElementById('root')
 if (!rootElement) {
@@ -10,8 +14,13 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <React.Suspense fallback={<div>加载中...</div>}>
-      <App />
-    </React.Suspense>
+    <LockProvider>
+      <React.Suspense fallback={<div>加载中...</div>}>
+        <App />
+      </React.Suspense>
+      <FabTools />
+      <LockScreen />
+      <IdleLock />
+    </LockProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add a lock context provider and lock screen overlay that requires the account password to unlock
- add an idle lock manager that persists a timeout preference and locks after inactivity
- expose floating tools with a manual lock button and idle timeout selector, wired up at the app root

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6cabb8f48331b9f6d282a7026841