### PR TITLE
Switch Tauri config to capability-based permissions

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Base capability for the application's main window.",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "shell:allow-open",
+    {
+      "identifier": "fs:allow-read-dir",
+      "allow": [
+        { "path": "$DOCUMENT/*" },
+        { "path": "$APPDATA/vault/*" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-read-file",
+      "allow": [
+        { "path": "$DOCUMENT/*" },
+        { "path": "$APPDATA/vault/*" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-write-file",
+      "allow": [
+        { "path": "$APPDATA/vault/*" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-mkdir",
+      "allow": [
+        { "path": "$APPDATA/vault/*" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-remove",
+      "allow": [
+        { "path": "$APPDATA/vault/*" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-exists",
+      "allow": [
+        { "path": "$APPDATA/vault/*" }
+      ]
+    }
+  ]
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,23 +5,27 @@
   "identifier": "com.pms.web",
   "build": {
     "beforeDevCommand": "pnpm dev",
+    "beforeBuildCommand": "pnpm build",
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173"
   },
   "bundle": {
-    "icon": ["icons/icon.ico", "icons/icon.icns"]
+    "icon": [
+      "icons/icon.ico",
+      "icons/icon.icns"
+    ]
   },
-  "tauri": {
-    "allowlist": {
-      "fs": {
-        "all": true
-      },
-      "path": {
-        "all": true
-      },
-      "shell": {
-        "all": true
+  "app": {
+    "security": {
+      "capabilities": ["default"]
+    },
+    "windows": [
+      {
+        "title": "pms-web",
+        "width": 1200,
+        "height": 800,
+        "resizable": true
       }
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- update `tauri.conf.json` to use a capability reference and declare both dev/build commands
- define a `default` capability with the shell and fs permissions needed for vault access

## Testing
- `TAURI_SKIP_DEVSERVER=1 pnpm tauri dev --no-dev-server-wait --no-dev-server` *(fails: missing gio/gobject system libraries in container)*
- `pnpm tauri build` *(fails: existing TypeScript errors in project build)*

------
https://chatgpt.com/codex/tasks/task_e_68ce74ba65488331ad2f0b6ec5f6fb58