### PR TITLE
Update Vite dev server ports to 5173

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -73,11 +73,11 @@ export default defineConfig(async () => {
     plugins,
     ...(isTauri ? { base: './' } : {}),
     server: {
-      port: 1420,
+      port: 5173,
       strictPort: true
     },
     preview: {
-      port: 1420,
+      port: 5173,
       strictPort: true
     },
     resolve: {


### PR DESCRIPTION
## Summary
- update Vite dev and preview server ports to 5173 to align with Tauri configuration

## Testing
- pnpm tauri dev *(fails: missing system libraries `glib-2.0` and `gobject-2.0` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce800b90808331b4d313ab747a1eee