### PR TITLE
Add SQLite storage backend and shared database adapter

### DIFF
--- a/src/stores/sqlite.ts
+++ b/src/stores/sqlite.ts
@@ -1,0 +1,350 @@
+import { Database } from '@tauri-apps/plugin-sql'
+import { mkdir } from '@tauri-apps/plugin-fs'
+import { appDataDir, join } from '@tauri-apps/api/path'
+import type {
+  DatabaseClient,
+  DocRecord,
+  OwnedCollection,
+  PasswordRecord,
+  SiteRecord,
+  UserRecord,
+  UsersTable,
+} from './database'
+
+type SqliteRow = Record<string, unknown>
+
+type Migration = {
+  version: number
+  run(connection: Database): Promise<void>
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 0
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined) return undefined
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined
+  return String(value)
+}
+
+function serializeDocument(document: DocRecord['document']): string | null {
+  if (!document) return null
+  try {
+    return JSON.stringify(document)
+  } catch (error) {
+    console.warn('Failed to serialize document payload for SQLite storage', error)
+    return null
+  }
+}
+
+function parseDocument(value: unknown): DocRecord['document'] {
+  if (typeof value !== 'string' || !value.trim()) return undefined
+  try {
+    return JSON.parse(value) as DocRecord['document']
+  } catch (error) {
+    console.warn('Failed to parse stored document payload from SQLite', error)
+    return undefined
+  }
+}
+
+function normalizeParams(values: unknown[]): unknown[] {
+  return values.map(item => (item === undefined ? null : item))
+}
+
+async function resolveDatabasePath() {
+  const baseDir = await appDataDir()
+  await mkdir(baseDir, { recursive: true })
+  return join(baseDir, 'app.sqlite')
+}
+
+const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    async run(connection) {
+      await connection.execute(`
+        CREATE TABLE IF NOT EXISTS users (
+          email TEXT PRIMARY KEY,
+          salt TEXT NOT NULL,
+          keyHash TEXT NOT NULL,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL
+        )
+      `)
+      await connection.execute(`
+        CREATE TABLE IF NOT EXISTS passwords (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          ownerEmail TEXT NOT NULL,
+          title TEXT NOT NULL,
+          username TEXT NOT NULL,
+          passwordCipher TEXT NOT NULL,
+          url TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL
+        )
+      `)
+      await connection.execute(`
+        CREATE TABLE IF NOT EXISTS sites (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          ownerEmail TEXT NOT NULL,
+          title TEXT NOT NULL,
+          url TEXT NOT NULL,
+          description TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL
+        )
+      `)
+      await connection.execute(`
+        CREATE TABLE IF NOT EXISTS docs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          ownerEmail TEXT NOT NULL,
+          title TEXT NOT NULL,
+          description TEXT,
+          document TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL
+        )
+      `)
+    },
+  },
+  {
+    version: 2,
+    async run(connection) {
+      await connection.execute('CREATE INDEX IF NOT EXISTS idx_passwords_ownerEmail ON passwords(ownerEmail)')
+      await connection.execute(
+        'CREATE INDEX IF NOT EXISTS idx_passwords_ownerEmail_updatedAt ON passwords(ownerEmail, updatedAt)',
+      )
+      await connection.execute('CREATE INDEX IF NOT EXISTS idx_sites_ownerEmail ON sites(ownerEmail)')
+      await connection.execute(
+        'CREATE INDEX IF NOT EXISTS idx_sites_ownerEmail_updatedAt ON sites(ownerEmail, updatedAt)',
+      )
+      await connection.execute('CREATE INDEX IF NOT EXISTS idx_docs_ownerEmail ON docs(ownerEmail)')
+      await connection.execute(
+        'CREATE INDEX IF NOT EXISTS idx_docs_ownerEmail_updatedAt ON docs(ownerEmail, updatedAt)',
+      )
+    },
+  },
+  {
+    version: 3,
+    async run(connection) {
+      const columns = await connection.select<{ name?: string }[]>(`PRAGMA table_info(docs)`)
+      const hasDocumentColumn = columns.some(column => column.name === 'document')
+      if (!hasDocumentColumn) {
+        await connection.execute('ALTER TABLE docs ADD COLUMN document TEXT')
+      }
+    },
+  },
+]
+
+async function runMigrations(connection: Database) {
+  const rows = await connection.select<{ user_version?: number }[]>(`PRAGMA user_version`)
+  const currentVersion = rows.length > 0 ? toNumber(rows[0]?.user_version) : 0
+  let version = currentVersion
+  for (const migration of MIGRATIONS) {
+    if (version < migration.version) {
+      await migration.run(connection)
+      await connection.execute(`PRAGMA user_version = ${migration.version}`)
+      version = migration.version
+    }
+  }
+}
+
+function createUsersCollection(connection: Database): UsersTable {
+  return {
+    async get(key) {
+      const rows = await connection.select<SqliteRow[]>(
+        'SELECT email, salt, keyHash, createdAt, updatedAt FROM users WHERE email = ? LIMIT 1',
+        [key],
+      )
+      const row = rows[0]
+      if (!row) return undefined
+      return {
+        email: String(row.email ?? ''),
+        salt: String(row.salt ?? ''),
+        keyHash: String(row.keyHash ?? ''),
+        createdAt: toNumber(row.createdAt),
+        updatedAt: toNumber(row.updatedAt),
+      }
+    },
+    async put(record) {
+      await connection.execute(
+        'INSERT OR REPLACE INTO users (email, salt, keyHash, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)',
+        [record.email, record.salt, record.keyHash, record.createdAt, record.updatedAt],
+      )
+      return record.email
+    },
+  }
+}
+
+function createOwnedCollection<T extends { id?: number; ownerEmail: string; createdAt: number; updatedAt: number }>(
+  connection: Database,
+  options: {
+    table: string
+    selectColumns: readonly string[]
+    mapRow: (row: SqliteRow) => T
+    prepareInsert: (record: T) => { columns: string[]; values: unknown[] }
+  },
+): OwnedCollection<T> {
+  const columnsList = options.selectColumns.join(', ')
+  return {
+    where: (_index: 'ownerEmail') => ({
+      equals: value => ({
+        toArray: async () => {
+          const rows = await connection.select<SqliteRow[]>(
+            `SELECT ${columnsList} FROM ${options.table} WHERE ownerEmail = ? ORDER BY updatedAt DESC, id DESC`,
+            [value],
+          )
+          return rows.map(options.mapRow)
+        },
+      }),
+    }),
+    async add(record) {
+      const { columns, values } = options.prepareInsert(record)
+      const placeholders = columns.map(() => '?').join(', ')
+      await connection.execute(
+        `INSERT INTO ${options.table} (${columns.join(', ')}) VALUES (${placeholders})`,
+        normalizeParams(values),
+      )
+      const rows = await connection.select<{ id?: number }[]>(`SELECT last_insert_rowid() as id`)
+      const inserted = rows[0]?.id
+      return toNumber(inserted)
+    },
+    async delete(key) {
+      await connection.execute(`DELETE FROM ${options.table} WHERE id = ?`, [key])
+    },
+  }
+}
+
+function mapPasswordRow(row: SqliteRow): PasswordRecord {
+  const createdAt = toNumber(row.createdAt)
+  const updatedAt = toNumber(row.updatedAt ?? createdAt)
+  return {
+    id: toOptionalNumber(row.id),
+    ownerEmail: String(row.ownerEmail ?? ''),
+    title: String(row.title ?? ''),
+    username: String(row.username ?? ''),
+    passwordCipher: String(row.passwordCipher ?? ''),
+    url: toOptionalString(row.url),
+    createdAt,
+    updatedAt,
+  }
+}
+
+function mapSiteRow(row: SqliteRow): SiteRecord {
+  const createdAt = toNumber(row.createdAt)
+  const updatedAt = toNumber(row.updatedAt ?? createdAt)
+  return {
+    id: toOptionalNumber(row.id),
+    ownerEmail: String(row.ownerEmail ?? ''),
+    title: String(row.title ?? ''),
+    url: String(row.url ?? ''),
+    description: toOptionalString(row.description),
+    createdAt,
+    updatedAt,
+  }
+}
+
+function mapDocRow(row: SqliteRow): DocRecord {
+  const createdAt = toNumber(row.createdAt)
+  const updatedAt = toNumber(row.updatedAt ?? createdAt)
+  return {
+    id: toOptionalNumber(row.id),
+    ownerEmail: String(row.ownerEmail ?? ''),
+    title: String(row.title ?? ''),
+    description: toOptionalString(row.description),
+    document: parseDocument(row.document),
+    createdAt,
+    updatedAt,
+  }
+}
+
+function preparePasswordInsert(record: PasswordRecord) {
+  return {
+    columns: ['ownerEmail', 'title', 'username', 'passwordCipher', 'url', 'createdAt', 'updatedAt'],
+    values: [
+      record.ownerEmail,
+      record.title,
+      record.username,
+      record.passwordCipher,
+      record.url ?? null,
+      record.createdAt,
+      record.updatedAt,
+    ],
+  }
+}
+
+function prepareSiteInsert(record: SiteRecord) {
+  return {
+    columns: ['ownerEmail', 'title', 'url', 'description', 'createdAt', 'updatedAt'],
+    values: [
+      record.ownerEmail,
+      record.title,
+      record.url,
+      record.description ?? null,
+      record.createdAt,
+      record.updatedAt,
+    ],
+  }
+}
+
+function prepareDocInsert(record: DocRecord) {
+  return {
+    columns: ['ownerEmail', 'title', 'description', 'document', 'createdAt', 'updatedAt'],
+    values: [
+      record.ownerEmail,
+      record.title,
+      record.description ?? null,
+      serializeDocument(record.document),
+      record.createdAt,
+      record.updatedAt,
+    ],
+  }
+}
+
+export async function createSqliteDatabase(): Promise<DatabaseClient> {
+  const dbPath = await resolveDatabasePath()
+  const identifier = `sqlite:${dbPath}`
+  const connection = await Database.load(identifier)
+  await connection.execute('PRAGMA foreign_keys = ON')
+  await connection.execute('PRAGMA journal_mode = WAL')
+  await runMigrations(connection)
+
+  const ready = Promise.resolve()
+
+  return {
+    open: () => ready,
+    users: createUsersCollection(connection),
+    passwords: createOwnedCollection(connection, {
+      table: 'passwords',
+      selectColumns: ['id', 'ownerEmail', 'title', 'username', 'passwordCipher', 'url', 'createdAt', 'updatedAt'],
+      mapRow: mapPasswordRow,
+      prepareInsert: preparePasswordInsert,
+    }),
+    sites: createOwnedCollection(connection, {
+      table: 'sites',
+      selectColumns: ['id', 'ownerEmail', 'title', 'url', 'description', 'createdAt', 'updatedAt'],
+      mapRow: mapSiteRow,
+      prepareInsert: prepareSiteInsert,
+    }),
+    docs: createOwnedCollection(connection, {
+      table: 'docs',
+      selectColumns: ['id', 'ownerEmail', 'title', 'description', 'document', 'createdAt', 'updatedAt'],
+      mapRow: mapDocRow,
+      prepareInsert: prepareDocInsert,
+    }),
+  }
+}

--- a/src/tauri-fs-stub.ts
+++ b/src/tauri-fs-stub.ts
@@ -1,0 +1,21 @@
+export async function readTextFile() {
+  return ''
+}
+
+export async function writeFile() {
+  return undefined
+}
+
+export async function mkdir() {
+  return undefined
+}
+
+export async function remove() {
+  return undefined
+}
+
+export async function exists() {
+  return false
+}
+
+export const BaseDirectory = { AppData: 'AppData' as const }

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DocRecord, PasswordRecord, UserRecord } from '../src/stores/database'
+
+async function resetEnvironment() {
+  vi.resetModules()
+  const sql = (await import('@tauri-apps/plugin-sql')) as any
+  if (sql.__mock) {
+    sql.__mock.reset()
+  }
+  return sql
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  delete (window as Record<string, unknown>).__TAURI_INTERNALS__
+})
+
+describe('sqlite database helpers', () => {
+  it('opens the database at the app data path and stores users', async () => {
+    const sql = await resetEnvironment()
+    const { createSqliteDatabase } = await import('../src/stores/sqlite')
+    const db = await createSqliteDatabase()
+
+    expect(sql.Database.load).toHaveBeenCalledWith('sqlite:C:/mock/AppData/pms-web/app.sqlite')
+
+    const now = Date.now()
+    const user: UserRecord = {
+      email: 'user@example.com',
+      salt: 'salt',
+      keyHash: 'hash',
+      createdAt: now,
+      updatedAt: now,
+    }
+    await db.users.put(user)
+    await expect(db.users.get('user@example.com')).resolves.toEqual(user)
+  })
+
+  it('filters owned password records by ownerEmail', async () => {
+    await resetEnvironment()
+    const { createSqliteDatabase } = await import('../src/stores/sqlite')
+    const db = await createSqliteDatabase()
+
+    const now = Date.now()
+    const first: PasswordRecord = {
+      ownerEmail: 'a@example.com',
+      title: 'First',
+      username: 'alice',
+      passwordCipher: 'cipher-a',
+      url: undefined,
+      createdAt: now,
+      updatedAt: now,
+    }
+    const second: PasswordRecord = {
+      ownerEmail: 'b@example.com',
+      title: 'Second',
+      username: 'bob',
+      passwordCipher: 'cipher-b',
+      url: undefined,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await db.passwords.add(first)
+    await db.passwords.add(second)
+
+    const rows = await db.passwords.where('ownerEmail').equals('a@example.com').toArray()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.title).toBe('First')
+  })
+
+  it('persists document payloads as JSON', async () => {
+    await resetEnvironment()
+    const { createSqliteDatabase } = await import('../src/stores/sqlite')
+    const db = await createSqliteDatabase()
+
+    const now = Date.now()
+    const doc: DocRecord = {
+      ownerEmail: 'doc@example.com',
+      title: 'Doc',
+      description: 'desc',
+      document: { kind: 'link', link: { url: 'https://example.com' } },
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await db.docs.add(doc)
+    const rows = await db.docs.where('ownerEmail').equals('doc@example.com').toArray()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.document).toEqual(doc.document)
+  })
+})
+
+describe('database module selection', () => {
+  it('uses Dexie helpers in the browser environment', async () => {
+    const sql = await resetEnvironment()
+    const { db } = await import('../src/stores/database')
+    expect(typeof db.open).toBe('function')
+    expect(sql.Database.load).not.toHaveBeenCalled()
+  })
+
+  it('uses SQLite helpers when Tauri internals are present', async () => {
+    const sql = await resetEnvironment()
+    ;(window as Record<string, unknown>).__TAURI_INTERNALS__ = {}
+    const { db } = await import('../src/stores/database')
+    expect(sql.Database.load).toHaveBeenCalled()
+
+    const now = Date.now()
+    const record: PasswordRecord = {
+      ownerEmail: 'tauri@example.com',
+      title: 'Entry',
+      username: 'user',
+      passwordCipher: 'cipher',
+      url: undefined,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await db.passwords.add(record)
+    const rows = await db.passwords.where('ownerEmail').equals('tauri@example.com').toArray()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.title).toBe('Entry')
+  })
+})

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,43 +1,266 @@
-import { vi } from 'vitest';
+import { vi } from 'vitest'
+
+type RowRecord = Record<string, unknown>
+
+type ConnectionRecord = {
+  identifier: string
+  db: MockSqliteDatabase
+}
+
+class MockSqliteDatabase {
+  private tables = new Map<string, RowRecord[]>()
+  private columns = new Map<string, string[]>()
+  private autoIds = new Map<string, number>()
+  private lastInsertId = 0
+  private userVersion = 0
+
+  constructor(public readonly identifier: string) {}
+
+  async execute(query: string, params: unknown[] = []) {
+    const trimmed = query.trim()
+    if (!trimmed) return
+
+    if (/^PRAGMA\s+foreign_keys/i.test(trimmed)) return
+    if (/^PRAGMA\s+journal_mode/i.test(trimmed)) return
+
+    const userVersionMatch = trimmed.match(/^PRAGMA\s+user_version\s*=\s*(\d+)/i)
+    if (userVersionMatch) {
+      this.userVersion = Number(userVersionMatch[1]) || 0
+      return
+    }
+
+    const createTableMatch = trimmed.match(/^CREATE TABLE IF NOT EXISTS\s+(\w+)/i)
+    if (createTableMatch) {
+      const table = createTableMatch[1]
+      this.ensureTable(table)
+      this.captureColumns(table, trimmed)
+      return
+    }
+
+    const createIndexMatch = trimmed.match(/^CREATE INDEX IF NOT EXISTS/i)
+    if (createIndexMatch) return
+
+    const alterMatch = trimmed.match(/^ALTER TABLE\s+(\w+)\s+ADD COLUMN\s+(\w+)/i)
+    if (alterMatch) {
+      const [, table, column] = alterMatch
+      const columnList = this.columns.get(table)
+      if (columnList && !columnList.includes(column)) {
+        columnList.push(column)
+      }
+      const rows = this.tables.get(table)
+      if (rows) {
+        for (const row of rows) {
+          if (!(column in row)) {
+            row[column] = null
+          }
+        }
+      }
+      return
+    }
+
+    const insertMatch = trimmed.match(/^INSERT(?: OR REPLACE)? INTO\s+(\w+)\s*\(([^)]+)\)\s*VALUES\s*\(([^)]*)\)/i)
+    if (insertMatch) {
+      const [, table, columnSection] = insertMatch
+      const columns = columnSection.split(',').map(part => part.trim())
+      const normalized = (Array.isArray(params) ? params : [params]).map(value =>
+        value === undefined ? null : value,
+      )
+      const record: RowRecord = {}
+      columns.forEach((column, index) => {
+        record[column] = normalized[index] ?? null
+      })
+
+      if (table === 'users') {
+        const rows = this.ensureTable(table)
+        const email = record.email
+        const index = rows.findIndex(entry => entry.email === email)
+        if (index >= 0) {
+          rows[index] = { ...rows[index], ...record }
+        } else {
+          rows.push({ ...record })
+        }
+        return
+      }
+
+      const rows = this.ensureTable(table)
+      if (record.id === undefined || record.id === null) {
+        const nextId = (this.autoIds.get(table) ?? 0) + 1
+        this.autoIds.set(table, nextId)
+        record.id = nextId
+      }
+      const index = rows.findIndex(entry => entry.id === record.id)
+      if (index >= 0) {
+        rows[index] = { ...rows[index], ...record }
+      } else {
+        rows.push({ ...record })
+      }
+      this.lastInsertId = Number(record.id) || 0
+      return
+    }
+
+    const deleteMatch = trimmed.match(/^DELETE FROM\s+(\w+)\s+WHERE\s+id\s*=\s*\?/i)
+    if (deleteMatch) {
+      const table = deleteMatch[1]
+      const id = Array.isArray(params) ? params[0] : params
+      const rows = this.ensureTable(table)
+      const index = rows.findIndex(entry => entry.id === id)
+      if (index >= 0) rows.splice(index, 1)
+      return
+    }
+
+    throw new Error(`Unhandled SQL execute mock: ${query}`)
+  }
+
+  async select<T = RowRecord>(query: string, params: unknown[] = []): Promise<T[]> {
+    const trimmed = query.trim()
+    if (/^PRAGMA\s+user_version/i.test(trimmed)) {
+      return [{ user_version: this.userVersion } as T]
+    }
+
+    const tableInfoMatch = trimmed.match(/^PRAGMA\s+table_info\((\w+)\)/i)
+    if (tableInfoMatch) {
+      const table = tableInfoMatch[1]
+      const columns = this.columns.get(table) ?? []
+      return columns.map((name, cid) => ({ cid, name })) as T[]
+    }
+
+    if (/^SELECT\s+last_insert_rowid\(\)\s+AS\s+id/i.test(trimmed)) {
+      return [{ id: this.lastInsertId }] as T[]
+    }
+
+    const whereMatch = trimmed.match(
+      /^SELECT\s+(.+?)\s+FROM\s+(\w+)\s+WHERE\s+(\w+)\s*=\s*\?(?:\s+ORDER BY\s+(.+?))?(?:\s+LIMIT\s+(\d+))?$/i,
+    )
+    if (whereMatch) {
+      const [, columnSection, table, field, orderSection, limitSection] = whereMatch
+      const target = Array.isArray(params) ? params[0] : params
+      const rows = [...this.ensureTable(table)].filter(entry => entry[field] === target)
+      if (orderSection) {
+        const directives = orderSection
+          .split(',')
+          .map(part => part.trim())
+          .filter(Boolean)
+        rows.sort((a, b) => {
+          for (const directive of directives) {
+            const [columnName, rawDirection] = directive.split(/\s+/)
+            const dir = rawDirection && rawDirection.toUpperCase() === 'DESC' ? -1 : 1
+            const key = columnName?.replace(/[`"']/g, '') ?? ''
+            const av = Number(a[key] ?? 0)
+            const bv = Number(b[key] ?? 0)
+            if (av === bv) continue
+            return av > bv ? dir : -dir
+          }
+          return 0
+        })
+      }
+      const columns = columnSection.split(',').map(part => part.trim())
+      let results = rows.map(row => this.pickColumns(row, columns)) as T[]
+      if (limitSection) {
+        const limit = Number(limitSection)
+        if (Number.isFinite(limit)) {
+          results = results.slice(0, limit)
+        }
+      }
+      return results
+    }
+
+    throw new Error(`Unhandled SQL select mock: ${query}`)
+  }
+
+  private ensureTable(name: string) {
+    if (!this.tables.has(name)) {
+      this.tables.set(name, [])
+    }
+    if (!this.columns.has(name)) {
+      this.columns.set(name, [])
+    }
+    return this.tables.get(name) as RowRecord[]
+  }
+
+  private captureColumns(table: string, definition: string) {
+    const start = definition.indexOf('(')
+    const end = definition.lastIndexOf(')')
+    if (start === -1 || end === -1 || end <= start) return
+    const body = definition.slice(start + 1, end)
+    const parts = body
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean)
+    const names = parts.map(part => part.split(/\s+/)[0])
+    this.columns.set(table, names)
+  }
+
+  private pickColumns(row: RowRecord, columns: string[]): RowRecord {
+    if (columns.length === 1 && columns[0] === '*') {
+      return { ...row }
+    }
+    const result: RowRecord = {}
+    for (const column of columns) {
+      const clean = column.replace(/\s+AS\s+.+$/i, '')
+      result[clean] = row[clean]
+    }
+    return result
+  }
+}
+
+const connections: ConnectionRecord[] = []
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
   readTextFile: vi.fn(),
   writeFile: vi.fn(),
-  mkdir: vi.fn(),
+  mkdir: vi.fn().mockResolvedValue(undefined),
   remove: vi.fn(),
   exists: vi.fn().mockResolvedValue(true),
   BaseDirectory: { AppData: 'AppData' },
-}));
+}))
+
 vi.mock('@tauri-apps/api/path', () => ({
   appDataDir: vi.fn().mockResolvedValue('C:/mock/AppData/pms-web'),
   join: vi.fn().mockImplementation((...parts: string[]) => parts.join('/')),
-}));
-vi.mock('@tauri-apps/plugin-sql', () => ({
-  Database: { load: vi.fn().mockResolvedValue({ execute: vi.fn(), select: vi.fn() }) }
-}));
+}))
+
+vi.mock('@tauri-apps/plugin-sql', () => {
+  const load = vi.fn(async (identifier: string) => {
+    const db = new MockSqliteDatabase(identifier)
+    connections.push({ identifier, db })
+    return db
+  })
+  const reset = () => {
+    connections.length = 0
+    load.mockClear()
+  }
+  return {
+    Database: { load },
+    __mock: { connections, reset },
+  }
+})
+
 vi.mock('../src/lib/crypto', () => ({
   encryptString: vi.fn(async (_k: Uint8Array, v: string) => v),
   decryptString: vi.fn(async (_k: Uint8Array, v: string) => v),
-}));
+}))
+
 vi.mock('react-dom/test-utils', async () => {
-  const actual = await vi.importActual<any>('react-dom/test-utils');
-  const { act } = await import('react');
-  return { ...actual, act };
-});
-import { Blob } from 'node:buffer';
-(globalThis as any).Blob = Blob;
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
-const originalError = console.error;
+  const actual = await vi.importActual<any>('react-dom/test-utils')
+  const { act } = await import('react')
+  return { ...actual, act }
+})
+
+import { Blob } from 'node:buffer'
+;(globalThis as any).Blob = Blob
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const originalError = console.error
 console.error = (...args: unknown[]) => {
-  const first = args[0];
+  const first = args[0]
   if (typeof first === 'string') {
     if (
       first.includes('ReactDOMTestUtils.act') ||
       first.includes('not wrapped in act') ||
       first.includes('not configured to support act')
     ) {
-      return;
+      return
     }
   }
-  originalError(...args);
-};
+  originalError(...args)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
         __dirname,
         'src/tauri-stronghold-stub.ts'
       ),
+      '@tauri-apps/plugin-fs': path.resolve(__dirname, 'src/tauri-fs-stub.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- add a SQLite-backed storage module with migrations and CRUD helpers used in Tauri builds
- update the database store to expose a unified interface that swaps between SQLite and Dexie depending on the runtime
- extend the Vitest setup with SQLite mocks, filesystem stubs, and new database tests covering the shared API

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ce85b9012c83319ccccf4da6a12c11