### PR TITLE
Update Vite dev server configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,12 +71,18 @@ export default defineConfig(async () => {
 
   return {
     plugins,
-    ...(isTauri ? { base: './' } : {}),
+    base: './',
     server: {
+      host: true,
       port: 5173,
-      strictPort: true
+      strictPort: true,
+      watch: {
+        usePolling: true,
+        interval: 200
+      }
     },
     preview: {
+      host: true,
       port: 5173,
       strictPort: true
     },


### PR DESCRIPTION
## Summary
- add polling configuration and host binding to the dev and preview servers
- always apply a './' base path in the Vite config

## Testing
- pnpm tauri:dev *(fails: Failed to parse version `2` for crate `tauri-plugin-fs`)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8d3515fc8331bd618138a60993ae