### PR TITLE
Fix TypeScript issues with Tauri integrations

### DIFF
--- a/src/features/lock/LockScreen.tsx
+++ b/src/features/lock/LockScreen.tsx
@@ -24,7 +24,7 @@ export function LockScreen() {
     setSubmitting(true)
     setError(null)
     try {
-      const result = await login(email, password)
+      const result = await login(email ?? '', password ?? '')
       if (result.success) {
         setPassword('')
         unlock()

--- a/src/routes/Docs.tsx
+++ b/src/routes/Docs.tsx
@@ -1,5 +1,11 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { importFileToVault, openDocument, removeVaultFile, type VaultFileMeta } from '../lib/vault'
+import {
+  importFileToVault,
+  openDocument,
+  removeVaultFile,
+  type StoredDocument,
+  type VaultFileMeta,
+} from '../lib/vault'
 import { db, type DocRecord } from '../stores/database'
 import { useAuthStore } from '../stores/auth'
 
@@ -100,14 +106,14 @@ export default function Docs() {
       return
     }
 
-    const document =
-      fileMeta && linkMeta
-        ? { kind: 'file+link', file: fileMeta, link: linkMeta }
-        : fileMeta
-        ? { kind: 'file', file: fileMeta }
-        : linkMeta
-        ? { kind: 'link', link: linkMeta }
-        : undefined
+    let document: StoredDocument | undefined
+    if (fileMeta && linkMeta) {
+      document = { kind: 'file+link', file: fileMeta, link: linkMeta }
+    } else if (fileMeta) {
+      document = { kind: 'file', file: fileMeta }
+    } else if (linkMeta) {
+      document = { kind: 'link', link: linkMeta }
+    }
 
     const now = Date.now()
 

--- a/src/stores/database.ts
+++ b/src/stores/database.ts
@@ -193,7 +193,8 @@ function createDexieClient(): DatabaseClient {
 }
 
 const isTauri =
-  typeof window !== 'undefined' && Boolean((window as Record<string, unknown>).__TAURI_INTERNALS__)
+  typeof window !== 'undefined' &&
+  typeof (window as any).__TAURI_INTERNALS__ !== 'undefined'
 
 let dbInstance: DatabaseClient
 

--- a/src/stores/sqlite.ts
+++ b/src/stores/sqlite.ts
@@ -1,4 +1,4 @@
-import { Database } from '@tauri-apps/plugin-sql'
+import Database from '@tauri-apps/plugin-sql'
 import { mkdir } from '@tauri-apps/plugin-fs'
 import { appDataDir, join } from '@tauri-apps/api/path'
 import type {
@@ -142,7 +142,8 @@ const MIGRATIONS: Migration[] = [
     version: 3,
     async run(connection) {
       const columns = await connection.select<{ name?: string }[]>(`PRAGMA table_info(docs)`)
-      const hasDocumentColumn = columns.some(column => column.name === 'document')
+      type ColumnInfo = { name: string }
+      const hasDocumentColumn = (columns as ColumnInfo[]).some((column) => column.name === 'document')
       if (!hasDocumentColumn) {
         await connection.execute('ALTER TABLE docs ADD COLUMN document TEXT')
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,6 +72,9 @@ export default defineConfig(async () => {
   return {
     plugins,
     base: './',
+    build: {
+      target: 'esnext',
+    },
     server: {
       host: true,
       port: 5173,


### PR DESCRIPTION
## Summary
- ensure the lock screen login call always receives string credentials
- construct stored documents in Docs with explicit unions and tighten Tauri checks
- update the SQLite bridge import, column typing, and set the Vite build target for top-level await support

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce9a4fcb908331b90e097f55e6bb2d