### PR TITLE
feat: add theme tokens and settings route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Dashboard from './routes/Dashboard'
 import Passwords from './routes/Passwords'
 import Sites from './routes/Sites'
 import Docs from './routes/Docs'
+import Settings from './routes/Settings'
 
 function GuestLayout({ children }: { children: ReactNode }) {
   return (
@@ -79,6 +80,14 @@ function AuthenticatedLayout() {
             >
               文档管理
             </NavLink>
+            <NavLink
+              to="/dashboard/settings"
+              className={({ isActive }) =>
+                `rounded-full px-4 py-2 transition ${isActive ? 'bg-white text-slate-900' : 'text-slate-200 hover:bg-white/10'}`
+              }
+            >
+              设置
+            </NavLink>
           </div>
         </nav>
       </header>
@@ -146,6 +155,7 @@ export default function App() {
           <Route path="passwords" element={<Passwords />} />
           <Route path="sites" element={<Sites />} />
           <Route path="docs" element={<Docs />} />
+          <Route path="settings" element={<Settings />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/index.css
+++ b/src/index.css
@@ -2,32 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: light;
-  --color-primary: 51 112 255;
-  --color-background: 245 246 248;
-  --color-surface: 255 255 255;
-  --color-surface-hover: 242 243 245;
-  --color-border: 222 225 230;
-  --color-text: 31 35 41;
-  --color-text-muted: 134 136 144;
-}
-.dark {
-  color-scheme: dark;
-  --color-primary: 83 140 255;
-  --color-background: 32 34 37;
-  --color-surface: 45 47 51;
-  --color-surface-hover: 56 59 63;
-  --color-border: 62 66 73;
-  --color-text: 238 239 241;
-  --color-text-muted: 166 168 173;
-}
 html, body, #root { height: 100%; }
 body { @apply font-sans bg-background text-text; }
 table { border-collapse: collapse; }
 th, td { border-color: #eee; }
 a { color: rgb(var(--color-primary)); }
-button { outline: none }
 
 
 @keyframes flash { 0%{background:#fef3c7} 100%{background:transparent} }
@@ -51,9 +30,6 @@ button { outline: none }
 a { word-break: break-all; }
 
 /* 更好的焦点可见性 */
-:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
-
-
 /* Base form controls */
 input[type="text"], input[type="url"], input[type="password"], input[type="email"], textarea, select {
   border-radius: 0.75rem;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import './styles/tokens.css'
 import './index.css'
 import App from './App'
 import FabTools from './components/FabTools'

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,0 +1,99 @@
+import clsx from 'clsx'
+import type { ChangeEvent } from 'react'
+import { useTheme, type ThemePreference } from '../stores/theme'
+
+type ThemeOption = {
+  label: string
+  value: ThemePreference
+  description: string
+}
+
+const THEME_OPTIONS: ThemeOption[] = [
+  {
+    label: '跟随系统',
+    value: 'system',
+    description: '自动与当前操作系统的外观保持一致。',
+  },
+  {
+    label: '浅色',
+    value: 'light',
+    description: '始终使用明亮清爽的浅色界面。',
+  },
+  {
+    label: '深色',
+    value: 'dark',
+    description: '在所有页面中使用深色界面。',
+  },
+]
+
+export default function Settings() {
+  const { preference, resolved, setPreference } = useTheme()
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const next = event.currentTarget.value as ThemePreference
+    setPreference(next)
+  }
+
+  return (
+    <div className="space-y-8 text-text">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-text">设置</h1>
+        <p className="text-sm text-muted">调整主题外观与个性化选项。</p>
+      </header>
+
+      <section className="space-y-5 rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-sm">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium text-text">主题模式</h2>
+          <p className="text-sm text-muted">
+            当前显示：{resolved === 'dark' ? '深色主题' : '浅色主题'}
+          </p>
+        </div>
+        <fieldset className="grid gap-3 sm:grid-cols-3" aria-label="主题模式">
+          {THEME_OPTIONS.map(option => {
+            const checked = preference === option.value
+            return (
+              <label
+                key={option.value}
+                className={clsx(
+                  'group relative flex cursor-pointer flex-col gap-2 rounded-xl border p-4 transition-colors duration-200',
+                  'focus-within:ring-2 focus-within:ring-primary/40 focus-within:ring-offset-2 focus-within:ring-offset-background',
+                  checked
+                    ? 'border-primary/70 bg-primary/10 shadow-[0_0_0_1px_rgba(96,165,250,0.35)]'
+                    : 'border-border/60 bg-surface/70 hover:border-border hover:bg-surface'
+                )}
+              >
+                <input
+                  type="radio"
+                  name="theme-preference"
+                  value={option.value}
+                  checked={checked}
+                  onChange={handleChange}
+                  className="sr-only"
+                />
+                <span className="flex items-center gap-3 text-sm font-medium text-text">
+                  <span
+                    className={clsx(
+                      'grid h-5 w-5 place-content-center rounded-full border-2 transition-colors duration-200',
+                      checked
+                        ? 'border-primary bg-primary/20 text-primary'
+                        : 'border-border/70 bg-surface text-transparent'
+                    )}
+                  >
+                    <span
+                      className={clsx(
+                        'h-2.5 w-2.5 rounded-full bg-primary transition-opacity duration-200',
+                        checked ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                  </span>
+                  {option.label}
+                </span>
+                <p className="text-xs leading-relaxed text-muted">{option.description}</p>
+              </label>
+            )
+          })}
+        </fieldset>
+      </section>
+    </div>
+  )
+}

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -1,0 +1,136 @@
+import { create } from 'zustand'
+
+export type ThemePreference = 'system' | 'light' | 'dark'
+export type ThemeMode = 'light' | 'dark'
+
+type ThemeState = {
+  preference: ThemePreference
+  resolved: ThemeMode
+  setPreference: (preference: ThemePreference) => void
+}
+
+const THEME_STORAGE_KEY = 'pms-web-theme'
+const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)'
+
+const mediaQuery: MediaQueryList | null =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia(COLOR_SCHEME_QUERY)
+    : null
+
+function parsePreference(value: string | null): ThemePreference {
+  if (value === 'light' || value === 'dark' || value === 'system') {
+    return value
+  }
+  return 'system'
+}
+
+function readStoredPreference(): ThemePreference {
+  if (typeof window === 'undefined') {
+    return 'system'
+  }
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+    return parsePreference(stored)
+  } catch (error) {
+    console.warn('Failed to read theme preference from localStorage', error)
+    return 'system'
+  }
+}
+
+function resolveMode(preference: ThemePreference, matchesOverride?: boolean): ThemeMode {
+  if (preference === 'system') {
+    if (typeof matchesOverride === 'boolean') {
+      return matchesOverride ? 'dark' : 'light'
+    }
+    if (mediaQuery) {
+      return mediaQuery.matches ? 'dark' : 'light'
+    }
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      return window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light'
+    }
+    return 'light'
+  }
+  return preference
+}
+
+function persistPreference(preference: ThemePreference) {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, preference)
+  } catch (error) {
+    console.error('Failed to persist theme preference', error)
+  }
+}
+
+function applyTheme(preference: ThemePreference, mode: ThemeMode) {
+  if (typeof document === 'undefined') {
+    return
+  }
+  const root = document.documentElement
+  root.dataset.theme = mode
+  root.dataset.themePreference = preference
+  root.style.colorScheme = mode
+  root.classList.toggle('dark', mode === 'dark')
+}
+
+const initialPreference = readStoredPreference()
+const initialResolved = resolveMode(initialPreference)
+
+applyTheme(initialPreference, initialResolved)
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  preference: initialPreference,
+  resolved: initialResolved,
+  setPreference(preference) {
+    if (preference === get().preference) {
+      const resolved = resolveMode(preference)
+      if (resolved !== get().resolved) {
+        applyTheme(preference, resolved)
+        set({ resolved })
+      }
+      return
+    }
+    const resolved = resolveMode(preference)
+    persistPreference(preference)
+    applyTheme(preference, resolved)
+    set({ preference, resolved })
+  },
+}))
+
+if (mediaQuery) {
+  const handleMediaChange = (event: MediaQueryListEvent) => {
+    const { preference } = useThemeStore.getState()
+    if (preference !== 'system') {
+      return
+    }
+    const resolved = resolveMode('system', event.matches)
+    applyTheme('system', resolved)
+    useThemeStore.setState({ resolved })
+  }
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handleMediaChange)
+  } else {
+    mediaQuery.addListener(handleMediaChange)
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', event => {
+    if (event.key !== THEME_STORAGE_KEY) {
+      return
+    }
+    const preference = parsePreference(event.newValue)
+    const resolved = resolveMode(preference)
+    applyTheme(preference, resolved)
+    useThemeStore.setState({ preference, resolved })
+  })
+}
+
+export function useTheme() {
+  return useThemeStore()
+}
+
+export { THEME_STORAGE_KEY }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,225 @@
+:root {
+  /* Neutral palette */
+  --gray-50: #f8fafc;
+  --gray-100: #f1f5f9;
+  --gray-200: #e2e8f0;
+  --gray-300: #cbd5f5;
+  --gray-400: #94a3b8;
+  --gray-500: #64748b;
+  --gray-600: #475569;
+  --gray-700: #334155;
+  --gray-800: #1e293b;
+  --gray-900: #0f172a;
+  --gray-950: #020617;
+
+  /* Accent palette */
+  --blue-50: #eff6ff;
+  --blue-100: #dbeafe;
+  --blue-200: #bfdbfe;
+  --blue-300: #93c5fd;
+  --blue-400: #60a5fa;
+  --blue-500: #3b82f6;
+  --blue-600: #2563eb;
+  --blue-700: #1d4ed8;
+  --blue-800: #1e40af;
+  --blue-900: #1e3a8a;
+
+  /* Support palette */
+  --emerald-500: #22c55e;
+  --amber-500: #f59e0b;
+  --rose-500: #f43f5e;
+
+  /* Spacing scale */
+  --space-3xs: 0.125rem;
+  --space-2xs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  --space-3xl: 4rem;
+
+  /* Radius scale */
+  --radius-xs: 0.375rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.5rem;
+  --radius-full: 9999px;
+
+  /* Typography */
+  --font-sans: 'Inter', 'SF Pro Display', 'SF Pro Text', 'PingFang SC', 'Microsoft YaHei',
+    system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.75;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Focus ring */
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
+  --focus-ring-color: rgba(59, 130, 246, 0.45);
+  --focus-ring-shadow: 0 0 0 4px rgba(59, 130, 246, 0.25);
+
+  /* Default (light) theme tokens */
+  --color-background: 248 250 252;
+  --color-surface: 255 255 255;
+  --color-surface-hover: 241 245 249;
+  --color-border: 226 232 240;
+  --color-foreground: 15 23 42;
+  --color-muted: 100 116 139;
+  --color-heading: 15 23 42;
+  --color-primary: 59 130 246;
+  --color-primary-foreground: 245 250 255;
+  --color-positive: 34 197 94;
+  --color-warning: 245 158 11;
+  --color-danger: 244 63 94;
+  --color-text: var(--color-foreground);
+  --color-text-muted: var(--color-muted);
+
+  color-scheme: light;
+  font-family: var(--font-sans);
+  background-color: rgb(var(--color-background));
+  color: rgb(var(--color-foreground));
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  --focus-ring-color: rgba(59, 130, 246, 0.45);
+  --focus-ring-shadow: 0 0 0 4px rgba(59, 130, 246, 0.2);
+  --color-background: 248 250 252;
+  --color-surface: 255 255 255;
+  --color-surface-hover: 241 245 249;
+  --color-border: 226 232 240;
+  --color-foreground: 15 23 42;
+  --color-muted: 100 116 139;
+  --color-heading: 15 23 42;
+  --color-primary: 59 130 246;
+  --color-primary-foreground: 245 250 255;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --focus-ring-color: rgba(147, 197, 253, 0.6);
+  --focus-ring-shadow: 0 0 0 4px rgba(59, 130, 246, 0.35);
+  --color-background: 9 13 23;
+  --color-surface: 17 24 39;
+  --color-surface-hover: 30 41 59;
+  --color-border: 51 65 85;
+  --color-foreground: 226 232 240;
+  --color-muted: 148 163 184;
+  --color-heading: 226 232 240;
+  --color-primary: 96 165 250;
+  --color-primary-foreground: 13 20 35;
+}
+
+:root[data-theme-preference='system'] {
+  --focus-ring-color: rgba(59, 130, 246, 0.5);
+}
+
+* {
+  margin: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+  background-color: rgb(var(--color-background));
+  color: rgb(var(--color-foreground));
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe {
+  display: block;
+  max-width: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+button,
+[role='button'] {
+  cursor: pointer;
+}
+
+button {
+  background-color: transparent;
+  border: none;
+}
+
+input,
+textarea,
+select {
+  background-color: rgb(var(--color-surface));
+}
+
+::selection {
+  background-color: rgb(var(--color-primary) / 0.2);
+}
+
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-shadow);
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add design token stylesheet with palettes, spacing, typography, focus styles, and theme variants
- create theme store to sync prefers-color-scheme, localStorage, and document attributes
- build settings page with theme controls and register it in the dashboard navigation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cea1176d148331bcf306ffc7665eaa