### PR TITLE
feat: add shared layout and ui primitives

### DIFF
--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,101 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { AlertTriangle, RefreshCw, Send } from 'lucide-react'
+
+export interface AppErrorBoundaryProps {
+  children: ReactNode
+  title?: ReactNode
+  description?: ReactNode
+  onFeedback?: () => void
+  feedbackHref?: string
+  onReset?: () => void
+}
+
+interface AppErrorBoundaryState {
+  hasError: boolean
+  error?: Error | null
+}
+
+export default class AppErrorBoundary extends Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  }
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Uncaught error', error, info)
+  }
+
+  handleRefresh = () => {
+    if (this.props.onReset) {
+      this.props.onReset()
+      this.setState({ hasError: false, error: null })
+      return
+    }
+    if (typeof window !== 'undefined') {
+      window.location.reload()
+    }
+  }
+
+  handleFeedback = () => {
+    const { onFeedback, feedbackHref } = this.props
+    if (onFeedback) {
+      onFeedback()
+      return
+    }
+    if (feedbackHref && typeof window !== 'undefined') {
+      window.open(feedbackHref, '_blank', 'noreferrer')
+    }
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children
+    }
+
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6 py-10 text-text">
+        <div className="max-w-lg rounded-3xl border border-border bg-surface px-8 py-10 text-center shadow-lg">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <AlertTriangle className="h-8 w-8" aria-hidden />
+          </div>
+          <h1 className="mt-6 text-2xl font-semibold text-text">
+            {this.props.title ?? '出现了一些问题'}
+          </h1>
+          <p className="mt-3 text-sm text-muted">
+            {this.props.description ?? '页面加载失败，请刷新后再试。如果问题持续存在，欢迎反馈给我们。'}
+          </p>
+          {this.state.error ? (
+            <pre className="mt-5 max-h-40 overflow-auto rounded-2xl bg-surface-hover px-4 py-3 text-left text-xs text-muted">
+              {this.state.error.message}
+            </pre>
+          ) : null}
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <button
+              type="button"
+              onClick={this.handleRefresh}
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white transition hover:bg-primary/90"
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden />
+              <span>刷新页面</span>
+            </button>
+            <button
+              type="button"
+              onClick={this.handleFeedback}
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-6 py-3 text-sm font-medium text-text transition hover:bg-surface-hover"
+            >
+              <Send className="h-4 w-4" aria-hidden />
+              <span>反馈问题</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,0 +1,258 @@
+import {
+  Fragment,
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { ChevronDown, Plus, Search } from 'lucide-react'
+import clsx from 'clsx'
+
+export interface AppNavItem {
+  key: string
+  label: ReactNode
+  icon?: ReactNode
+  description?: ReactNode
+  badge?: ReactNode
+  href?: string
+  onSelect?: (key: string) => void
+}
+
+export interface AppLayoutProps {
+  children: ReactNode
+  navItems: AppNavItem[]
+  activeNavKey?: string
+  onNavigate?: (key: string) => void
+  title?: ReactNode
+  subtitle?: ReactNode
+  logo?: ReactNode
+  toolbarChildren?: ReactNode
+  newActions?: Array<{
+    key: string
+    label: ReactNode
+    description?: ReactNode
+    icon?: ReactNode
+  }>
+  onNew?: (key: string) => void
+  onSearch?: (value: string) => void
+  searchPlaceholder?: string
+  className?: string
+}
+
+function isAnchorTarget(item: AppNavItem): item is AppNavItem & { href: string } {
+  return typeof item.href === 'string' && item.href.length > 0
+}
+
+export default function AppLayout({
+  children,
+  navItems,
+  activeNavKey,
+  onNavigate,
+  title,
+  subtitle,
+  logo,
+  toolbarChildren,
+  newActions = [],
+  onNew,
+  onSearch,
+  searchPlaceholder = '搜索内容…',
+  className,
+}: AppLayoutProps) {
+  const [search, setSearch] = useState('')
+  const [isNewMenuOpen, setIsNewMenuOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement | null>(null)
+
+  const hasNewMenu = newActions.length > 0 && typeof onNew === 'function'
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (!dropdownRef.current) return
+      if (dropdownRef.current.contains(event.target as Node)) return
+      setIsNewMenuOpen(false)
+    }
+
+    if (isNewMenuOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isNewMenuOpen])
+
+  useEffect(() => {
+    if (!isNewMenuOpen) return undefined
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        setIsNewMenuOpen(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleEscape)
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape)
+    }
+  }, [isNewMenuOpen])
+
+  const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    onSearch?.(search.trim())
+  }
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value)
+    onSearch?.(value)
+  }
+
+  const navList = useMemo(
+    () =>
+      navItems.map(item => {
+        const isActive = item.key === activeNavKey
+        const commonClass = clsx(
+          'group flex w-full items-center gap-3 rounded-xl border border-transparent px-4 py-3 text-sm font-medium transition',
+          isActive
+            ? 'bg-primary/10 text-primary'
+            : 'text-muted hover:border-border hover:bg-surface-hover hover:text-text',
+        )
+
+        const content = (
+          <Fragment>
+            {item.icon ? <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-hover text-muted">{item.icon}</span> : null}
+            <div className="flex flex-1 flex-col items-start gap-1 text-left">
+              <span className="text-sm font-medium leading-none">{item.label}</span>
+              {item.description ? (
+                <span className="text-xs text-muted/80">{item.description}</span>
+              ) : null}
+            </div>
+            {item.badge ? (
+              <span className="ml-auto inline-flex min-w-[1.75rem] items-center justify-center rounded-full bg-surface-hover px-2 text-[11px] font-semibold text-muted">
+                {item.badge}
+              </span>
+            ) : null}
+          </Fragment>
+        )
+
+        if (isAnchorTarget(item)) {
+          return (
+            <a
+              key={item.key}
+              href={item.href}
+              className={commonClass}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {content}
+            </a>
+          )
+        }
+
+        return (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => {
+              item.onSelect?.(item.key)
+              onNavigate?.(item.key)
+            }}
+            className={commonClass}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {content}
+          </button>
+        )
+      }),
+    [navItems, activeNavKey, onNavigate],
+  )
+
+  return (
+    <div className={clsx('flex min-h-screen bg-background text-text', className)}>
+      <aside className="hidden w-72 flex-col border-r border-border bg-surface px-6 py-8 lg:flex">
+        <div className="flex items-center gap-3">
+          {logo ? <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">{logo}</div> : null}
+          <div className="flex flex-1 flex-col">
+            {title ? <h1 className="text-base font-semibold text-text">{title}</h1> : null}
+            {subtitle ? <p className="text-sm text-muted">{subtitle}</p> : null}
+          </div>
+        </div>
+        <nav className="mt-8 flex-1 space-y-2" aria-label="主要导航">
+          {navList}
+        </nav>
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <header className="sticky top-0 z-20 border-b border-border/80 bg-surface/95 backdrop-blur">
+          <div className="flex flex-col gap-3 px-4 py-4 md:flex-row md:items-center md:justify-between md:px-6">
+            <form onSubmit={handleSearchSubmit} className="flex flex-1 items-center gap-3 rounded-full border border-border bg-surface-hover px-4 py-2">
+              <Search className="h-4 w-4 text-muted" aria-hidden />
+              <input
+                type="search"
+                value={search}
+                onChange={event => handleSearchChange(event.target.value)}
+                placeholder={searchPlaceholder}
+                className="flex-1 bg-transparent text-sm text-text placeholder:text-muted focus:outline-none"
+                aria-label="搜索内容"
+              />
+            </form>
+            <div className="flex items-center gap-3 md:justify-end">
+              {toolbarChildren}
+              {hasNewMenu ? (
+                <div className="relative" ref={dropdownRef}>
+                  <button
+                    type="button"
+                    onClick={() => setIsNewMenuOpen(prev => !prev)}
+                    className="inline-flex items-center gap-2 rounded-full bg-primary/90 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary"
+                    aria-haspopup="menu"
+                    aria-expanded={isNewMenuOpen}
+                  >
+                    <Plus className="h-4 w-4" aria-hidden />
+                    <span>新建</span>
+                    <ChevronDown className="h-4 w-4" aria-hidden />
+                  </button>
+                  {isNewMenuOpen ? (
+                    <div
+                      role="menu"
+                      aria-label="新建菜单"
+                      className="absolute right-0 z-30 mt-2 w-60 rounded-xl border border-border bg-surface shadow-lg"
+                    >
+                      <ul className="py-2 text-sm text-text">
+                        {newActions.map(action => (
+                          <li key={action.key}>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              onClick={() => {
+                                setIsNewMenuOpen(false)
+                                onNew?.(action.key)
+                              }}
+                              className="flex w-full items-start gap-3 px-4 py-2 text-left transition hover:bg-surface-hover"
+                            >
+                              {action.icon ? (
+                                <span className="mt-0.5 text-muted">{action.icon}</span>
+                              ) : null}
+                              <span className="flex flex-1 flex-col">
+                                <span className="font-medium">{action.label}</span>
+                                {action.description ? (
+                                  <span className="text-xs text-muted">{action.description}</span>
+                                ) : null}
+                              </span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </header>
+        <main className="flex-1 overflow-y-auto bg-background px-4 py-6 md:px-8 md:py-8">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,286 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import Fuse from 'fuse.js'
+import type { IFuseOptions } from 'fuse.js'
+import { ArrowUpRight, PlusCircle, Search, X } from 'lucide-react'
+import clsx from 'clsx'
+
+export interface CommandEntity {
+  id: string
+  title: string
+  type: string
+  description?: string
+  keywords?: string[]
+  tags?: string[]
+  icon?: ReactNode
+  data?: unknown
+}
+
+export interface CommandPaletteAction {
+  key: string
+  label: string
+  description?: string
+  icon?: ReactNode
+}
+
+export interface CommandPaletteProps {
+  open: boolean
+  entities: CommandEntity[]
+  onClose: () => void
+  onOpen: (entity: CommandEntity) => void
+  newActions?: CommandPaletteAction[]
+  onCreate?: (actionKey: string) => void
+  placeholder?: string
+  emptyMessage?: ReactNode
+}
+
+const fuseOptions: IFuseOptions<CommandEntity> = {
+  keys: [
+    { name: 'title', weight: 0.5 },
+    { name: 'description', weight: 0.3 },
+    { name: 'keywords', weight: 0.2 },
+    { name: 'tags', weight: 0.2 },
+  ],
+  threshold: 0.35,
+  ignoreLocation: true,
+  includeMatches: false,
+  minMatchCharLength: 1,
+}
+
+function stopScroll(open: boolean) {
+  if (typeof document === 'undefined') return
+  document.body.style.overflow = open ? 'hidden' : ''
+}
+
+export default function CommandPalette({
+  open,
+  entities,
+  onClose,
+  onOpen,
+  newActions = [],
+  onCreate,
+  placeholder = '搜索命令或条目…',
+  emptyMessage = '没有匹配的结果',
+}: CommandPaletteProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const listboxId = useId()
+
+  const fuse = useMemo(() => new Fuse(entities, fuseOptions), [entities])
+
+  const results = useMemo(() => {
+    if (!query.trim()) {
+      return entities
+    }
+    return fuse.search(query.trim()).map(item => item.item)
+  }, [entities, fuse, query])
+
+  useEffect(() => {
+    if (!open) return
+    setQuery('')
+    setActiveIndex(0)
+    stopScroll(true)
+    const timeout = window.setTimeout(() => {
+      inputRef.current?.focus()
+    }, 0)
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      stopScroll(false)
+    }
+  }, [open])
+
+  useEffect(() => {
+    return () => {
+      stopScroll(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open) return undefined
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => {
+      window.removeEventListener('keydown', handleKey)
+    }
+  }, [open, onClose])
+
+  const handleKeyNavigation = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!results.length) return
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setActiveIndex(prev => (prev + 1) % results.length)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setActiveIndex(prev => (prev - 1 + results.length) % results.length)
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setActiveIndex(0)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setActiveIndex(results.length - 1)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      const activeItem = results[activeIndex]
+      if (activeItem) {
+        onOpen(activeItem)
+        onClose()
+      }
+    }
+  }
+
+  if (typeof document === 'undefined' || !open) {
+    return null
+  }
+
+  return createPortal(
+    <div
+      ref={containerRef}
+      className="fixed inset-0 z-40 flex items-start justify-center bg-black/40 px-4 py-10 sm:py-20"
+      aria-modal="true"
+      role="dialog"
+      aria-label="命令面板"
+      onMouseDown={event => {
+        if (event.target === containerRef.current) {
+          onClose()
+        }
+      }}
+    >
+      <div
+        className="relative w-full max-w-2xl overflow-hidden rounded-2xl border border-border bg-surface shadow-xl"
+        onKeyDown={handleKeyNavigation}
+      >
+        <div className="flex items-center gap-3 border-b border-border px-5 py-4">
+          <Search className="h-4 w-4 text-muted" aria-hidden />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={event => {
+              setQuery(event.target.value)
+              setActiveIndex(0)
+            }}
+            placeholder={placeholder}
+            className="flex-1 bg-transparent text-sm text-text placeholder:text-muted focus:outline-none"
+            aria-controls={listboxId}
+            aria-label="搜索命令"
+          />
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-muted transition hover:bg-surface-hover hover:text-text"
+            aria-label="关闭命令面板"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+        {newActions.length > 0 ? (
+          <div className="border-b border-border bg-surface px-5 py-3 text-sm text-text">
+            <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-wide text-muted">快速新建</div>
+            <div className="flex flex-col gap-1">
+              {newActions.map(action => (
+                <button
+                  key={action.key}
+                  type="button"
+                  onClick={() => {
+                    onCreate?.(action.key)
+                    onClose()
+                  }}
+                  className="flex w-full items-center gap-3 rounded-xl border border-transparent px-3 py-2 text-left transition hover:border-border hover:bg-surface-hover"
+                >
+                  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-hover text-primary">
+                    {action.icon ?? <PlusCircle className="h-4 w-4" aria-hidden />}
+                  </span>
+                  <span className="flex flex-1 flex-col">
+                    <span className="text-sm font-medium">{action.label}</span>
+                    {action.description ? (
+                      <span className="text-xs text-muted">{action.description}</span>
+                    ) : null}
+                  </span>
+                  <ArrowUpRight className="h-4 w-4 text-muted" aria-hidden />
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        <div className="max-h-80 overflow-y-auto">
+          {results.length > 0 ? (
+            <ul id={listboxId} role="listbox" aria-label="搜索结果" className="divide-y divide-border/60">
+              {results.map((item, index) => {
+                const isActive = index === activeIndex
+                return (
+                  <li key={item.id} role="presentation">
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={isActive}
+                      onClick={() => {
+                        onOpen(item)
+                        onClose()
+                      }}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      className={clsx(
+                        'flex w-full items-start gap-3 px-5 py-3 text-left text-sm transition',
+                        isActive
+                          ? 'bg-primary/10 text-text'
+                          : 'text-text hover:bg-surface-hover',
+                      )}
+                    >
+                      {item.icon ? (
+                        <span className="mt-1 flex h-9 w-9 items-center justify-center rounded-xl bg-surface-hover text-primary">
+                          {item.icon}
+                        </span>
+                      ) : null}
+                      <span className="flex flex-1 flex-col gap-1">
+                        <span className="text-base font-medium text-text">{item.title}</span>
+                        {item.description ? (
+                          <span className="text-xs text-muted">{item.description}</span>
+                        ) : null}
+                        {item.tags && item.tags.length > 0 ? (
+                          <span className="flex flex-wrap gap-2 text-[11px] text-muted">
+                            {item.tags.map(tag => (
+                              <span
+                                key={tag}
+                                className="rounded-full border border-border px-2 py-0.5"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="ml-auto inline-flex h-6 items-center rounded-full bg-surface-hover px-2 text-[11px] font-medium text-muted">
+                        {item.type}
+                      </span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          ) : (
+            <div className="px-6 py-12 text-center text-sm text-muted">{emptyMessage}</div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,173 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import clsx from 'clsx'
+
+export interface ConfirmDialogProps {
+  open: boolean
+  title: ReactNode
+  description?: ReactNode
+  confirmLabel?: ReactNode
+  cancelLabel?: ReactNode
+  tone?: 'primary' | 'danger'
+  confirmButtonProps?: ButtonHTMLAttributes<HTMLButtonElement>
+  onConfirm: () => void
+  onCancel: () => void
+  disableConfirm?: boolean
+  loading?: boolean
+}
+
+function getFocusableElements(container: HTMLElement | null) {
+  if (!container) return []
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+    ),
+  )
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = '确认',
+  cancelLabel = '取消',
+  tone = 'primary',
+  confirmButtonProps,
+  onConfirm,
+  onCancel,
+  disableConfirm = false,
+  loading = false,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null)
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+  const titleId = useId()
+  const descriptionId = useId()
+
+  useEffect(() => {
+    if (!open) return undefined
+
+    restoreFocusRef.current = (document.activeElement as HTMLElement) ?? null
+
+    const timer = window.setTimeout(() => {
+      confirmButtonRef.current?.focus()
+    }, 0)
+
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (open) return
+    const restoreTarget = restoreFocusRef.current
+    if (restoreTarget) {
+      restoreTarget.focus()
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return undefined
+
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCancel()
+        return
+      }
+      if (event.key === 'Tab') {
+        const focusables = getFocusableElements(dialogRef.current)
+        if (focusables.length === 0) {
+          event.preventDefault()
+          return
+        }
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+    }
+  }, [open, onCancel])
+
+  const confirmToneClass = useMemo(() => {
+    if (tone === 'danger') {
+      return 'bg-surface text-text border border-border'
+    }
+    return 'bg-primary text-white'
+  }, [tone])
+
+  if (!open || typeof document === 'undefined') {
+    return null
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 px-4 py-6"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={description ? descriptionId : undefined}
+      onMouseDown={event => {
+        if (event.target === event.currentTarget) {
+          onCancel()
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="w-full max-w-md rounded-2xl border border-border bg-surface p-6 text-text shadow-xl"
+      >
+        <h2 id={titleId} className="text-lg font-semibold">
+          {title}
+        </h2>
+        {description ? (
+          <p id={descriptionId} className="mt-2 text-sm text-muted">
+            {description}
+          </p>
+        ) : null}
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex items-center justify-center rounded-full border border-border bg-surface-hover px-4 py-2 text-sm font-medium text-text transition hover:bg-surface"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            {...confirmButtonProps}
+            ref={confirmButtonRef}
+            type="button"
+            onClick={onConfirm}
+            disabled={disableConfirm || loading || confirmButtonProps?.disabled}
+            className={clsx(
+              'inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
+              confirmToneClass,
+              (disableConfirm || loading || confirmButtonProps?.disabled) && 'opacity-70 pointer-events-none',
+              confirmButtonProps?.className,
+            )}
+          >
+            {loading ? '处理中…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/DetailsDrawer.tsx
+++ b/src/components/DetailsDrawer.tsx
@@ -1,0 +1,171 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+import clsx from 'clsx'
+
+export interface DetailsDrawerProps {
+  open: boolean
+  title?: ReactNode
+  description?: ReactNode
+  children: ReactNode
+  footer?: ReactNode
+  onClose: () => void
+  width?: 'sm' | 'md' | 'lg'
+  className?: string
+  headerActions?: ReactNode
+}
+
+const WIDTH_MAP: Record<NonNullable<DetailsDrawerProps['width']>, string> = {
+  sm: 'max-w-md',
+  md: 'max-w-xl',
+  lg: 'max-w-2xl',
+}
+
+function getFocusableElements(container: HTMLElement | null) {
+  if (!container) return []
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+    ),
+  )
+}
+
+export default function DetailsDrawer({
+  open,
+  title,
+  description,
+  children,
+  footer,
+  onClose,
+  width = 'lg',
+  className,
+  headerActions,
+}: DetailsDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement | null>(null)
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+  const titleId = useId()
+  const descriptionId = useId()
+
+  useEffect(() => {
+    if (!open) return undefined
+    restoreFocusRef.current = (document.activeElement as HTMLElement) ?? null
+    const timer = window.setTimeout(() => {
+      const focusables = getFocusableElements(drawerRef.current)
+      focusables[0]?.focus()
+    }, 0)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (open) return
+    restoreFocusRef.current?.focus()
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return undefined
+
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+        return
+      }
+      if (event.key === 'Tab') {
+        const focusables = getFocusableElements(drawerRef.current)
+        if (focusables.length === 0) {
+          event.preventDefault()
+          return
+        }
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+    }
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    document.body.style.overflow = open ? 'hidden' : ''
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [open])
+
+  const widthClass = useMemo(() => WIDTH_MAP[width], [width])
+
+  if (!open || typeof document === 'undefined') {
+    return null
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-40 flex justify-end bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? titleId : undefined}
+      aria-describedby={description ? descriptionId : undefined}
+      onMouseDown={event => {
+        if (event.target === event.currentTarget) {
+          onClose()
+        }
+      }}
+    >
+      <div
+        ref={drawerRef}
+        className={clsx(
+          'flex h-full w-full flex-col gap-4 border-l border-border bg-surface text-text shadow-2xl transition-transform duration-200 ease-out',
+          widthClass,
+          className,
+        )}
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-border px-6 py-5">
+          <div className="space-y-1">
+            {title ? (
+              <h2 id={titleId} className="text-lg font-semibold">
+                {title}
+              </h2>
+            ) : null}
+            {description ? (
+              <p id={descriptionId} className="text-sm text-muted">
+                {description}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            {headerActions}
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted transition hover:bg-surface-hover hover:text-text"
+              aria-label="关闭详情抽屉"
+            >
+              <X className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </header>
+        <div className="flex-1 overflow-y-auto px-6 py-4">{children}</div>
+        {footer ? <div className="border-t border-border bg-surface px-6 py-4">{footer}</div> : null}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/Empty.tsx
+++ b/src/components/Empty.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react'
+import clsx from 'clsx'
+
+export interface EmptyProps {
+  icon?: ReactNode
+  title: ReactNode
+  description?: ReactNode
+  action?: ReactNode
+  size?: 'sm' | 'md' | 'lg'
+  align?: 'center' | 'start'
+  className?: string
+}
+
+const SIZE_MAP: Record<NonNullable<EmptyProps['size']>, string> = {
+  sm: 'gap-2 text-sm',
+  md: 'gap-3 text-base',
+  lg: 'gap-4 text-lg',
+}
+
+export default function Empty({
+  icon,
+  title,
+  description,
+  action,
+  size = 'md',
+  align = 'center',
+  className,
+}: EmptyProps) {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col items-center rounded-2xl border border-dashed border-border bg-surface px-6 py-12 text-center text-muted',
+        SIZE_MAP[size],
+        align === 'start' && 'items-start text-left',
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      {icon ? (
+        <div className="mb-1 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-surface-hover text-primary">
+          {icon}
+        </div>
+      ) : null}
+      <div className="font-semibold text-text">{title}</div>
+      {description ? <p className="max-w-xl text-sm text-muted">{description}</p> : null}
+      {action ? <div className="mt-4 flex items-center justify-center gap-3 text-sm text-text">{action}</div> : null}
+    </div>
+  )
+}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,39 @@
+import { forwardRef, type HTMLAttributes } from 'react'
+import clsx from 'clsx'
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  radius?: 'sm' | 'md' | 'lg' | 'full'
+}
+
+const RADIUS_MAP: Record<NonNullable<SkeletonProps['radius']>, string> = {
+  sm: 'rounded-md',
+  md: 'rounded-xl',
+  lg: 'rounded-2xl',
+  full: 'rounded-full',
+}
+
+const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, radius = 'md', style, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={clsx(
+          'animate-pulse bg-surface-hover/70 text-transparent',
+          RADIUS_MAP[radius],
+          className,
+        )}
+        style={{
+          backgroundImage: 'linear-gradient(90deg, rgba(255,255,255,0), rgba(255,255,255,0.2), rgba(255,255,255,0))',
+          backgroundSize: '200% 100%',
+          ...style,
+        }}
+        aria-hidden="true"
+        {...rest}
+      />
+    )
+  },
+)
+
+Skeleton.displayName = 'Skeleton'
+
+export default Skeleton

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,188 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+import clsx from 'clsx'
+import { nanoid } from 'nanoid'
+
+export type ToastTone = 'default' | 'success' | 'danger' | 'info'
+
+export interface ToastAction {
+  label: string
+  onClick: () => void
+  ariaLabel?: string
+}
+
+export interface ToastOptions {
+  id?: string
+  title?: ReactNode
+  description?: ReactNode
+  tone?: ToastTone
+  action?: ToastAction
+  duration?: number
+  onDismiss?: () => void
+  className?: string
+}
+
+interface ToastState extends ToastOptions {
+  id: string
+  createdAt: number
+}
+
+interface ToastContextValue {
+  pushToast: (options: ToastOptions) => string
+  dismissToast: (id: string) => void
+}
+
+const DEFAULT_DURATION = 4_000
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined)
+
+function toneStyles(tone: ToastTone = 'default') {
+  switch (tone) {
+    case 'success':
+      return 'border border-border bg-primary/10 text-primary'
+    case 'danger':
+      return 'border border-border bg-surface text-text'
+    case 'info':
+      return 'border border-border bg-surface text-text'
+    case 'default':
+    default:
+      return 'border border-border bg-surface text-text'
+  }
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastState[]>([])
+  const timers = useRef<Map<string, number>>(new Map())
+
+  const removeToast = useCallback((id: string) => {
+    const timeoutId = timers.current.get(id)
+    if (typeof timeoutId === 'number') {
+      window.clearTimeout(timeoutId)
+      timers.current.delete(id)
+    }
+    setToasts(prev => {
+      const target = prev.find(item => item.id === id)
+      target?.onDismiss?.()
+      return prev.filter(item => item.id !== id)
+    })
+  }, [])
+
+  const pushToast = useCallback(
+    (options: ToastOptions) => {
+      const id = options.id ?? nanoid()
+      setToasts(prev => {
+        const existing = prev.find(item => item.id === id)
+        if (existing) {
+          return prev.map(item => (item.id === id ? { ...item, ...options, id, createdAt: Date.now() } : item))
+        }
+        return [...prev, { ...options, id, createdAt: Date.now() }]
+      })
+
+      const duration = options.duration ?? DEFAULT_DURATION
+      const existingTimeout = timers.current.get(id)
+      if (typeof existingTimeout === 'number') {
+        window.clearTimeout(existingTimeout)
+      }
+      if (duration > 0) {
+        const timeoutId = window.setTimeout(() => {
+          removeToast(id)
+        }, duration)
+        timers.current.set(id, timeoutId)
+      } else {
+        timers.current.delete(id)
+      }
+
+      return id
+    },
+    [removeToast],
+  )
+
+  useEffect(() => {
+    return () => {
+      timers.current.forEach(timeoutId => {
+        window.clearTimeout(timeoutId)
+      })
+      timers.current.clear()
+    }
+  }, [])
+
+  const dismissToast = useCallback(
+    (id: string) => {
+      removeToast(id)
+    },
+    [removeToast],
+  )
+
+  const value = useMemo<ToastContextValue>(() => ({ pushToast, dismissToast }), [pushToast, dismissToast])
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {typeof document !== 'undefined'
+        ? createPortal(
+            <div className="pointer-events-none fixed inset-0 z-50 flex flex-col items-center gap-3 px-4 py-6 sm:items-end sm:justify-end sm:px-6">
+              {toasts.map(toast => (
+                <div
+                  key={toast.id}
+                  role="status"
+                  aria-live="polite"
+                  className={clsx(
+                    'pointer-events-auto w-full max-w-sm overflow-hidden rounded-2xl shadow-lg backdrop-blur',
+                    toneStyles(toast.tone),
+                    toast.className,
+                  )}
+                >
+                  <div className="flex items-start gap-3 px-4 py-3">
+                    <div className="flex-1 space-y-1 text-sm">
+                      {toast.title ? <div className="font-semibold text-text">{toast.title}</div> : null}
+                      {toast.description ? <div className="text-muted">{toast.description}</div> : null}
+                      {toast.action ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            toast.action?.onClick()
+                            dismissToast(toast.id)
+                          }}
+                          className="mt-2 inline-flex items-center rounded-full border border-border px-3 py-1 text-xs font-medium text-text transition hover:bg-surface-hover"
+                          aria-label={toast.action.ariaLabel ?? toast.action.label}
+                        >
+                          {toast.action.label}
+                        </button>
+                      ) : null}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => dismissToast(toast.id)}
+                      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-muted transition hover:bg-surface-hover hover:text-text"
+                      aria-label="关闭通知"
+                    >
+                      <X className="h-4 w-4" aria-hidden />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>,
+            document.body,
+          )
+        : null}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}

--- a/src/components/VaultItemCard.tsx
+++ b/src/components/VaultItemCard.tsx
@@ -1,0 +1,175 @@
+import { type KeyboardEvent, type MouseEvent, type ReactNode } from 'react'
+import clsx from 'clsx'
+
+export type BadgeTone = 'neutral' | 'primary' | 'muted'
+
+export interface VaultItemCardBadge {
+  id: string
+  label: ReactNode
+  tone?: BadgeTone
+  className?: string
+}
+
+export interface VaultItemCardTag {
+  id: string
+  label: ReactNode
+  className?: string
+}
+
+export interface VaultItemCardProps {
+  title: ReactNode
+  description?: ReactNode
+  leadingVisual?: ReactNode
+  badges?: VaultItemCardBadge[]
+  tags?: VaultItemCardTag[]
+  updatedAt?: ReactNode
+  metadata?: ReactNode
+  actions?: ReactNode
+  footer?: ReactNode
+  isSelected?: boolean
+  disabled?: boolean
+  className?: string
+  onClick?: (event: MouseEvent<HTMLDivElement>) => void
+  onOpen?: () => void
+  onDoubleClick?: () => void
+  onFocus?: () => void
+  onBlur?: () => void
+}
+
+function resolveBadgeTone(tone: BadgeTone = 'neutral') {
+  switch (tone) {
+    case 'primary':
+      return 'bg-primary/10 text-primary'
+    case 'muted':
+      return 'bg-surface-hover text-muted'
+    case 'neutral':
+    default:
+      return 'bg-surface-hover text-text'
+  }
+}
+
+export default function VaultItemCard({
+  title,
+  description,
+  leadingVisual,
+  badges = [],
+  tags = [],
+  updatedAt,
+  metadata,
+  actions,
+  footer,
+  isSelected = false,
+  disabled = false,
+  className,
+  onClick,
+  onOpen,
+  onDoubleClick,
+  onFocus,
+  onBlur,
+}: VaultItemCardProps) {
+  const isInteractive = Boolean(onOpen || onDoubleClick || onClick)
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (disabled || !isInteractive) return
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      if (onOpen) {
+        onOpen()
+      } else {
+        onDoubleClick?.()
+      }
+    }
+  }
+
+  const handleDoubleClick = () => {
+    if (disabled || !isInteractive) return
+    if (onDoubleClick) {
+      onDoubleClick()
+    } else {
+      onOpen?.()
+    }
+  }
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (disabled) return
+    onClick?.(event)
+  }
+
+  return (
+    <article
+      role={isInteractive ? 'button' : undefined}
+      tabIndex={!disabled && isInteractive ? 0 : -1}
+      onKeyDown={handleKeyDown}
+      onDoubleClick={handleDoubleClick}
+      onClick={handleClick}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      aria-disabled={disabled || undefined}
+      className={clsx(
+        'group relative flex flex-col gap-4 rounded-2xl border border-border bg-surface p-5 text-text shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
+        disabled ? 'pointer-events-none opacity-60' : 'hover:border-primary/40 hover:shadow-md',
+        isInteractive && !disabled ? 'cursor-pointer' : 'cursor-default',
+        isSelected && 'ring-2 ring-primary/60',
+        className,
+      )}
+    >
+      {actions ? (
+        <div className="absolute right-4 top-4 flex gap-2 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100">
+          {actions}
+        </div>
+      ) : null}
+      <div className="flex items-start gap-4">
+        {leadingVisual ? (
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-surface-hover text-primary">
+            {leadingVisual}
+          </div>
+        ) : null}
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="truncate text-base font-semibold text-text">{title}</h3>
+            {badges.map(badge => (
+              <span
+                key={badge.id}
+                className={clsx(
+                  'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium',
+                  resolveBadgeTone(badge.tone),
+                  badge.className,
+                )}
+              >
+                {badge.label}
+              </span>
+            ))}
+          </div>
+          {description ? (
+            <p className="text-sm leading-relaxed text-muted">
+              {description}
+            </p>
+          ) : null}
+          {tags.length > 0 ? (
+            <div className="mt-1 flex flex-wrap gap-2">
+              {tags.map(tag => (
+                <span
+                  key={tag.id}
+                  className={clsx(
+                    'inline-flex items-center rounded-full border border-border px-2.5 py-1 text-xs text-muted',
+                    tag.className,
+                  )}
+                >
+                  {tag.label}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      {(updatedAt || metadata) && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted">
+          {updatedAt ? <span>最近更新：{updatedAt}</span> : null}
+          {metadata}
+        </div>
+      )}
+      {footer ? <div className="border-t border-border pt-4 text-sm text-muted">{footer}</div> : null}
+    </article>
+  )
+}

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect } from 'react'
+
+export interface UseGlobalShortcutsOptions {
+  enabled?: boolean
+  onCommandPalette?: () => void
+  onCreateNew?: () => void
+  onFocusSearch?: () => void
+  onEscape?: () => void
+  preventWhenInputFocused?: boolean
+}
+
+function isEditableElement(target: EventTarget | null) {
+  if (!target || !(target instanceof HTMLElement)) {
+    return false
+  }
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+    return true
+  }
+  return target.isContentEditable
+}
+
+export function useGlobalShortcuts({
+  enabled = true,
+  onCommandPalette,
+  onCreateNew,
+  onFocusSearch,
+  onEscape,
+  preventWhenInputFocused = true,
+}: UseGlobalShortcutsOptions = {}) {
+  const triggerCommandPalette = useCallback(() => {
+    onCommandPalette?.()
+  }, [onCommandPalette])
+
+  const triggerCreateNew = useCallback(() => {
+    onCreateNew?.()
+  }, [onCreateNew])
+
+  const triggerFocusSearch = useCallback(() => {
+    onFocusSearch?.()
+  }, [onFocusSearch])
+
+  const triggerEscape = useCallback(() => {
+    onEscape?.()
+  }, [onEscape])
+
+  useEffect(() => {
+    if (!enabled) return undefined
+
+    function handleKeydown(event: KeyboardEvent) {
+      if (preventWhenInputFocused && isEditableElement(event.target)) {
+        if (!(event.metaKey || event.ctrlKey)) {
+          return
+        }
+      }
+
+      const key = event.key.toLowerCase()
+      const isMeta = event.metaKey || event.ctrlKey
+
+      if (isMeta && key === 'k') {
+        event.preventDefault()
+        triggerCommandPalette()
+        return
+      }
+
+      if (isMeta && key === 'n') {
+        event.preventDefault()
+        triggerCreateNew()
+        return
+      }
+
+      if (!event.metaKey && !event.ctrlKey && !event.altKey && key === '/') {
+        if (preventWhenInputFocused && isEditableElement(event.target)) {
+          return
+        }
+        event.preventDefault()
+        triggerFocusSearch()
+        return
+      }
+
+      if (key === 'escape') {
+        triggerEscape()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+    }
+  }, [enabled, preventWhenInputFocused, triggerCommandPalette, triggerCreateNew, triggerFocusSearch, triggerEscape])
+
+  return {
+    triggerCommandPalette,
+    triggerCreateNew,
+    triggerFocusSearch,
+    triggerEscape,
+  }
+}


### PR DESCRIPTION
## Summary
- implement the AppLayout shell with navigation, search, and creation dropdown hooks
- add reusable vault item, empty state, skeleton, toast, confirm dialog, details drawer, and error boundary components
- introduce a command palette with fuzzy search plus global shortcut handling utilities

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cea1186d908331babb883cf952b64a