### PR TITLE
Set up main entry providers and theme initialization

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,26 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: light;
-  --color-primary: 51 112 255;
-  --color-background: 245 246 248;
-  --color-surface: 255 255 255;
-  --color-surface-hover: 242 243 245;
-  --color-border: 222 225 230;
-  --color-text: 31 35 41;
-  --color-text-muted: 134 136 144;
-}
-.dark {
-  color-scheme: dark;
-  --color-primary: 83 140 255;
-  --color-background: 32 34 37;
-  --color-surface: 45 47 51;
-  --color-surface-hover: 56 59 63;
-  --color-border: 62 66 73;
-  --color-text: 238 239 241;
-  --color-text-muted: 166 168 173;
-}
 html, body, #root { height: 100%; }
 body { @apply font-sans bg-background text-text; }
 table { border-collapse: collapse; }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import './styles/tokens.css'
 import './index.css'
 import App from './App'
 import FabTools from './components/FabTools'
+import { AppErrorBoundary } from './providers/AppErrorBoundary'
+import { CommandPaletteProvider } from './providers/CommandPaletteProvider'
+import { ThemeProvider, initializeTheme } from './providers/ThemeProvider'
+import { ToastProvider } from './providers/ToastProvider'
 import IdleLock from './features/lock/IdleLock'
 import { LockProvider } from './features/lock/LockProvider'
 import { LockScreen } from './features/lock/LockScreen'
+
+initializeTheme()
 
 const rootElement = document.getElementById('root')
 if (!rootElement) {
@@ -14,13 +21,21 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <LockProvider>
-      <React.Suspense fallback={<div>加载中...</div>}>
-        <App />
-      </React.Suspense>
-      <FabTools />
-      <LockScreen />
-      <IdleLock />
-    </LockProvider>
+    <AppErrorBoundary>
+      <ThemeProvider>
+        <ToastProvider>
+          <CommandPaletteProvider>
+            <LockProvider>
+              <React.Suspense fallback={<div>加载中...</div>}>
+                <App />
+              </React.Suspense>
+              <FabTools />
+              <LockScreen />
+              <IdleLock />
+            </LockProvider>
+          </CommandPaletteProvider>
+        </ToastProvider>
+      </ThemeProvider>
+    </AppErrorBoundary>
   </React.StrictMode>,
 )

--- a/src/providers/AppErrorBoundary.tsx
+++ b/src/providers/AppErrorBoundary.tsx
@@ -1,0 +1,75 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+export type AppErrorBoundaryProps = {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+type AppErrorBoundaryState = {
+  error: Error | null
+}
+
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  override state: AppErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error }
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Unexpected runtime error', error, info)
+  }
+
+  private handleReload = () => {
+    if (typeof window !== 'undefined') {
+      window.location.reload()
+    }
+  }
+
+  private handleReset = () => {
+    this.setState({ error: null })
+  }
+
+  override render() {
+    const { children, fallback } = this.props
+    const { error } = this.state
+
+    if (!error) {
+      return children
+    }
+
+    if (fallback) {
+      return fallback
+    }
+
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 py-12 text-slate-200">
+        <div className="w-full max-w-lg rounded-3xl border border-white/10 bg-slate-900/70 p-10 shadow-2xl shadow-slate-950/50">
+          <h1 className="text-2xl font-semibold text-white">应用出现错误</h1>
+          <p className="mt-3 text-sm leading-relaxed text-slate-300">
+            很抱歉，应用在运行时遇到了问题。您可以尝试刷新页面重新载入，或返回继续使用。
+          </p>
+          <pre className="mt-6 max-h-52 overflow-auto rounded-2xl border border-white/10 bg-black/40 p-4 text-xs leading-relaxed text-red-300">
+            {error.message}
+          </pre>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={this.handleReload}
+              className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2.5 text-sm font-semibold text-slate-900 shadow-lg shadow-slate-950/40 transition hover:bg-slate-200"
+            >
+              刷新页面
+            </button>
+            <button
+              type="button"
+              onClick={this.handleReset}
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-slate-100 transition hover:border-white/40 hover:bg-white/10"
+            >
+              返回应用
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/providers/CommandPaletteProvider.tsx
+++ b/src/providers/CommandPaletteProvider.tsx
@@ -1,0 +1,319 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { ReactNode } from 'react'
+
+type Command = {
+  id: string
+  title: string
+  run: () => void | Promise<void>
+  description?: string
+  section?: string
+  keywords?: string[]
+  shortcut?: string[]
+}
+
+type GlobalShortcut = {
+  id: string
+  keys: string[]
+  handler: (event: KeyboardEvent) => void
+  preventDefault?: boolean
+  enabled?: boolean
+  allowWhileTyping?: boolean
+}
+
+type CommandPaletteContextValue = {
+  commands: Command[]
+  isOpen: boolean
+  query: string
+  open: () => void
+  close: () => void
+  toggle: () => void
+  setQuery: (value: string) => void
+  registerCommand: (command: Command) => () => void
+  runCommand: (id: string) => void
+  registerShortcut: (shortcut: GlobalShortcut) => () => void
+}
+
+type NormalizedShortcut = {
+  key: string | null
+  meta: boolean
+  ctrl: boolean
+  alt: boolean
+  shift: boolean
+}
+
+type RegisteredShortcut = GlobalShortcut & { normalized: NormalizedShortcut }
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | undefined>(undefined)
+
+export function CommandPaletteProvider({ children }: { children: ReactNode }) {
+  const [commands, setCommands] = useState<Command[]>([])
+  const [isOpen, setIsOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const shortcuts = useRef<Map<string, RegisteredShortcut>>(new Map())
+
+  const open = useCallback(() => {
+    setIsOpen(true)
+    setQuery('')
+  }, [])
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+    setQuery('')
+  }, [])
+
+  const toggle = useCallback(() => {
+    setIsOpen(prev => {
+      const next = !prev
+      if (next) {
+        setQuery('')
+      }
+      return next
+    })
+  }, [])
+
+  const registerCommand = useCallback((command: Command) => {
+    setCommands(prev => {
+      const filtered = prev.filter(item => item.id !== command.id)
+      return [...filtered, command]
+    })
+
+    return () => {
+      setCommands(prev => prev.filter(item => item.id !== command.id))
+    }
+  }, [])
+
+  const registerShortcut = useCallback((shortcut: GlobalShortcut) => {
+    const normalized = normalizeShortcut(shortcut.keys)
+    const entry: RegisteredShortcut = { ...shortcut, normalized }
+    shortcuts.current.set(shortcut.id, entry)
+
+    return () => {
+      shortcuts.current.delete(shortcut.id)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    function handleKeydown(event: KeyboardEvent) {
+      shortcuts.current.forEach(shortcut => {
+        if (shortcut.enabled === false) return
+        if (!shortcut.allowWhileTyping && isEditableTarget(event.target)) return
+        if (matchShortcut(event, shortcut.normalized)) {
+          if (shortcut.preventDefault ?? true) {
+            event.preventDefault()
+          }
+          shortcut.handler(event)
+        }
+      })
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+    }
+  }, [])
+
+  useEffect(() => {
+    const unregisterMeta = registerShortcut({
+      id: 'command-palette:meta-k',
+      keys: ['Meta', 'K'],
+      preventDefault: true,
+      allowWhileTyping: false,
+      handler: () => {
+        toggle()
+      },
+    })
+
+    const unregisterCtrl = registerShortcut({
+      id: 'command-palette:ctrl-k',
+      keys: ['Control', 'K'],
+      preventDefault: true,
+      allowWhileTyping: false,
+      handler: () => {
+        toggle()
+      },
+    })
+
+    const unregisterMetaShiftP = registerShortcut({
+      id: 'command-palette:meta-shift-p',
+      keys: ['Meta', 'Shift', 'P'],
+      preventDefault: true,
+      allowWhileTyping: false,
+      handler: () => {
+        open()
+      },
+    })
+
+    return () => {
+      unregisterMeta()
+      unregisterCtrl()
+      unregisterMetaShiftP()
+    }
+  }, [registerShortcut, toggle, open])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined
+    }
+
+    const unregisterEscape = registerShortcut({
+      id: 'command-palette:escape',
+      keys: ['Escape'],
+      preventDefault: true,
+      allowWhileTyping: true,
+      handler: () => {
+        close()
+      },
+    })
+
+    return () => {
+      unregisterEscape()
+    }
+  }, [isOpen, registerShortcut, close])
+
+  const runCommand = useCallback(
+    (id: string) => {
+      const command = commands.find(item => item.id === id)
+      if (!command) return
+      try {
+        const result = command.run()
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          void (result as Promise<unknown>).catch(error => {
+            console.error('Failed to run command', error)
+          })
+        }
+      } catch (error) {
+        console.error('Failed to run command', error)
+      }
+      close()
+    },
+    [commands, close],
+  )
+
+  const sortedCommands = useMemo(() => {
+    return [...commands].sort((a, b) => a.title.localeCompare(b.title, 'zh-CN'))
+  }, [commands])
+
+  const value = useMemo(
+    () => ({
+      commands: sortedCommands,
+      isOpen,
+      query,
+      open,
+      close,
+      toggle,
+      setQuery,
+      registerCommand,
+      runCommand,
+      registerShortcut,
+    }),
+    [sortedCommands, isOpen, query, open, close, toggle, registerCommand, runCommand, registerShortcut],
+  )
+
+  return <CommandPaletteContext.Provider value={value}>{children}</CommandPaletteContext.Provider>
+}
+
+export function useCommandPalette() {
+  const context = useContext(CommandPaletteContext)
+  if (!context) {
+    throw new Error('useCommandPalette must be used within a CommandPaletteProvider')
+  }
+  return context
+}
+
+function normalizeShortcut(keys: string[]): NormalizedShortcut {
+  return keys.reduce<NormalizedShortcut>(
+    (acc, key) => {
+      const normalized = key.trim().toLowerCase()
+      switch (normalized) {
+        case 'meta':
+        case 'cmd':
+        case 'command':
+          acc.meta = true
+          break
+        case 'control':
+        case 'ctrl':
+          acc.ctrl = true
+          break
+        case 'alt':
+        case 'option':
+          acc.alt = true
+          break
+        case 'shift':
+          acc.shift = true
+          break
+        case 'esc':
+        case 'escape':
+          acc.key = 'escape'
+          break
+        case 'space':
+          acc.key = ' '
+          break
+        default:
+          acc.key = normalized
+      }
+      return acc
+    },
+    { key: null, meta: false, ctrl: false, alt: false, shift: false },
+  )
+}
+
+function matchShortcut(event: KeyboardEvent, shortcut: NormalizedShortcut) {
+  const key = normalizeEventKey(event.key)
+  if (shortcut.meta !== event.metaKey) return false
+  if (shortcut.ctrl !== event.ctrlKey) return false
+  if (shortcut.alt !== event.altKey) return false
+  if (shortcut.shift !== event.shiftKey) return false
+  if (shortcut.key && shortcut.key !== key) return false
+  if (!shortcut.key) {
+    if (key === 'meta' || key === 'control' || key === 'shift' || key === 'alt') {
+      return true
+    }
+    return false
+  }
+  return true
+}
+
+function normalizeEventKey(key: string) {
+  const normalized = key.length === 1 ? key.toLowerCase() : key.toLowerCase()
+  switch (normalized) {
+    case 'esc':
+      return 'escape'
+    case 'escape':
+      return 'escape'
+    case ' ':
+    case 'spacebar':
+      return ' '
+    case 'arrowup':
+      return 'arrowup'
+    case 'arrowdown':
+      return 'arrowdown'
+    case 'arrowleft':
+      return 'arrowleft'
+    case 'arrowright':
+      return 'arrowright'
+    default:
+      return normalized
+  }
+}
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  const tagName = target.tagName
+  if (target.isContentEditable) return true
+  return tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT'
+}

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -1,0 +1,136 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+
+type Theme = 'light' | 'dark'
+type ThemePreference = Theme | 'system'
+
+type ThemeContextValue = {
+  theme: ThemePreference
+  resolvedTheme: Theme
+  setTheme: (value: ThemePreference) => void
+  toggleTheme: () => void
+}
+
+const STORAGE_KEY = 'pms-theme-preference'
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemePreference>(() => getStoredThemePreference())
+  const [systemTheme, setSystemTheme] = useState<Theme>(() => getSystemTheme())
+
+  const resolvedTheme: Theme = theme === 'system' ? systemTheme : theme
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    applyTheme(resolvedTheme)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme)
+    } catch (error) {
+      console.warn('无法保存主题偏好', error)
+    }
+    return undefined
+  }, [resolvedTheme, theme])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    if (theme !== 'system') return undefined
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? 'dark' : 'light')
+    }
+
+    setSystemTheme(media.matches ? 'dark' : 'light')
+    media.addEventListener('change', handleChange)
+
+    return () => {
+      media.removeEventListener('change', handleChange)
+    }
+  }, [theme])
+
+  const setTheme = useCallback((value: ThemePreference) => {
+    setThemeState(value)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setThemeState(prev => {
+      if (prev === 'system') {
+        return resolvedTheme === 'dark' ? 'light' : 'dark'
+      }
+      return prev === 'dark' ? 'light' : 'dark'
+    })
+  }, [resolvedTheme])
+
+  const value = useMemo(
+    () => ({
+      theme,
+      resolvedTheme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, resolvedTheme, setTheme, toggleTheme],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}
+
+export function initializeTheme() {
+  if (typeof document === 'undefined') {
+    return
+  }
+  const preference = getStoredThemePreference()
+  const theme = preference === 'system' ? getSystemTheme() : preference
+  applyTheme(theme)
+}
+
+function getStoredThemePreference(): ThemePreference {
+  if (typeof window === 'undefined') {
+    return 'system'
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored
+    }
+    return 'system'
+  } catch (error) {
+    console.warn('无法读取主题偏好', error)
+    return 'system'
+  }
+}
+
+function getSystemTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light'
+  }
+
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark'
+  }
+
+  return 'light'
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') {
+    return
+  }
+  const root = document.documentElement
+  root.dataset.theme = theme
+  if (theme === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -1,0 +1,195 @@
+import clsx from 'clsx'
+import { nanoid } from 'nanoid'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+type ToastAction = {
+  label: string
+  onClick: () => void
+}
+
+type ToastOptions = {
+  id?: string
+  title?: string
+  description?: string
+  duration?: number
+  variant?: 'default' | 'success' | 'error' | 'warning'
+  action?: ToastAction
+}
+
+type Toast = ToastOptions & { id: string }
+
+type ToastContextValue = {
+  toasts: Toast[]
+  showToast: (options: ToastOptions) => string
+  dismissToast: (id: string) => void
+  clearToasts: () => void
+}
+
+const DEFAULT_DURATION = 5000
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined)
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id))
+    const timer = timers.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      timers.current.delete(id)
+    }
+  }, [])
+
+  const showToast = useCallback(
+    (options: ToastOptions) => {
+      const id = options.id ?? nanoid()
+      const nextToast: Toast = { ...options, id }
+
+      setToasts(prev => {
+        const filtered = prev.filter(item => item.id !== id)
+        return [...filtered, nextToast]
+      })
+
+      const duration = options.duration ?? DEFAULT_DURATION
+      if (duration !== Infinity) {
+        const timer = setTimeout(() => {
+          dismissToast(id)
+        }, duration)
+        const previous = timers.current.get(id)
+        if (previous) {
+          clearTimeout(previous)
+        }
+        timers.current.set(id, timer)
+      }
+
+      return id
+    },
+    [dismissToast],
+  )
+
+  const clearToasts = useCallback(() => {
+    timers.current.forEach(timer => {
+      clearTimeout(timer)
+    })
+    timers.current.clear()
+    setToasts([])
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      timers.current.forEach(timer => {
+        clearTimeout(timer)
+      })
+      timers.current.clear()
+    }
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      toasts,
+      showToast,
+      dismissToast,
+      clearToasts,
+    }),
+    [toasts, showToast, dismissToast, clearToasts],
+  )
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
+    </ToastContext.Provider>
+  )
+}
+
+type ToastViewportProps = {
+  toasts: Toast[]
+  onDismiss: (id: string) => void
+}
+
+function ToastViewport({ toasts, onDismiss }: ToastViewportProps) {
+  if (typeof document === 'undefined' || toasts.length === 0) {
+    return null
+  }
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-x-0 top-4 z-[60] mx-auto flex max-w-md flex-col gap-3 px-4 sm:inset-auto sm:right-6 sm:top-6 sm:mx-0 sm:w-96 sm:px-0">
+      {toasts.map(toast => {
+        const variant = toast.variant ?? 'default'
+        const accentClass = getVariantAccent(variant)
+        return (
+          <div
+            key={toast.id}
+            className={clsx(
+              'pointer-events-auto overflow-hidden rounded-2xl border border-white/10 bg-surface text-text shadow-xl shadow-slate-950/40 backdrop-blur transition',
+              'focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-slate-950 focus-within:outline-none',
+            )}
+          >
+            <div className={clsx('h-1 w-full', accentClass)} />
+            <div className="flex flex-col gap-2 px-4 py-3">
+              {toast.title ? <p className="text-sm font-semibold text-text">{toast.title}</p> : null}
+              {toast.description ? <p className="text-sm leading-relaxed text-muted">{toast.description}</p> : null}
+            </div>
+            <div className="flex items-center justify-end gap-2 border-t border-border bg-surface-hover px-4 py-2">
+              {toast.action ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    toast.action?.onClick()
+                    onDismiss(toast.id)
+                  }}
+                  className="rounded-full bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary transition hover:bg-primary/20"
+                >
+                  {toast.action.label}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => {
+                  onDismiss(toast.id)
+                }}
+                className="rounded-full px-3 py-1.5 text-xs text-muted transition hover:bg-border/50"
+              >
+                关闭
+              </button>
+            </div>
+          </div>
+        )
+      })}
+    </div>,
+    document.body,
+  )
+}
+
+function getVariantAccent(variant: Toast['variant']) {
+  switch (variant) {
+    case 'success':
+      return 'bg-emerald-400'
+    case 'error':
+      return 'bg-rose-400'
+    case 'warning':
+      return 'bg-amber-400'
+    default:
+      return 'bg-primary'
+  }
+}
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,23 @@
+:root,
+:root[data-theme='light'] {
+  color-scheme: light;
+  --color-primary: 51 112 255;
+  --color-background: 245 246 248;
+  --color-surface: 255 255 255;
+  --color-surface-hover: 242 243 245;
+  --color-border: 222 225 230;
+  --color-text: 31 35 41;
+  --color-text-muted: 134 136 144;
+}
+
+.dark,
+[data-theme='dark'] {
+  color-scheme: dark;
+  --color-primary: 83 140 255;
+  --color-background: 32 34 37;
+  --color-surface: 45 47 51;
+  --color-surface-hover: 56 59 63;
+  --color-border: 62 66 73;
+  --color-text: 238 239 241;
+  --color-text-muted: 166 168 173;
+}


### PR DESCRIPTION
## Summary
- import CSS tokens and initialize the saved theme before bootstrapping React
- add global providers for the error boundary, toast notifications, and command palette/global shortcuts
- expose reusable Theme, Toast, and Command Palette provider components along with design token CSS

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing mocked default export for @tauri-apps/plugin-sql in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cea118ba488331aa16b7908235351a