### PR TITLE
feat: wire theme tokens across layouts and surfaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import Settings from './routes/Settings'
 
 function GuestLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
+    <div className="min-h-screen bg-background text-text transition-colors">
       <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-12">
         {children}
       </div>
@@ -25,33 +25,37 @@ function AuthenticatedLayout() {
   const logout = useAuthStore(s => s.logout)
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-white/10 bg-slate-900/80 backdrop-blur">
+    <div className="min-h-screen bg-background text-text transition-colors">
+      <header className="border-b border-border/60 bg-surface/80 backdrop-blur">
         <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-white">离线管理工具</h1>
-            <p className="text-sm text-slate-300">管理密码、网站与文档，数据仅保存在本地。</p>
+            <h1 className="text-2xl font-semibold text-text">离线管理工具</h1>
+            <p className="text-sm text-muted">管理密码、网站与文档，数据仅保存在本地。</p>
           </div>
-          <div className="flex items-center gap-4 text-sm text-slate-200">
+          <div className="flex items-center gap-4 text-sm text-text/80">
             <span className="truncate">{email}</span>
             <button
               type="button"
               onClick={() => {
                 void logout()
               }}
-              className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 font-medium text-white transition hover:border-white/40 hover:bg-white/10"
+              className="inline-flex items-center justify-center rounded-full border border-border/60 px-4 py-2 font-medium text-text transition hover:border-border hover:bg-surface-hover"
             >
               登出
             </button>
           </div>
         </div>
-        <nav className="border-t border-white/5">
+        <nav className="border-t border-border/60">
           <div className="mx-auto flex w-full max-w-5xl gap-4 px-6 py-3 text-sm">
             <NavLink
               to="/dashboard"
               end
               className={({ isActive }) =>
-                `rounded-full px-4 py-2 transition ${isActive ? 'bg-white text-slate-900' : 'text-slate-200 hover:bg-white/10'}`
+                `rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-primary text-background'
+                    : 'text-muted hover:bg-surface-hover hover:text-text'
+                }`
               }
             >
               总览
@@ -59,7 +63,11 @@ function AuthenticatedLayout() {
             <NavLink
               to="/dashboard/passwords"
               className={({ isActive }) =>
-                `rounded-full px-4 py-2 transition ${isActive ? 'bg-white text-slate-900' : 'text-slate-200 hover:bg-white/10'}`
+                `rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-primary text-background'
+                    : 'text-muted hover:bg-surface-hover hover:text-text'
+                }`
               }
             >
               密码库
@@ -67,7 +75,11 @@ function AuthenticatedLayout() {
             <NavLink
               to="/dashboard/sites"
               className={({ isActive }) =>
-                `rounded-full px-4 py-2 transition ${isActive ? 'bg-white text-slate-900' : 'text-slate-200 hover:bg-white/10'}`
+                `rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-primary text-background'
+                    : 'text-muted hover:bg-surface-hover hover:text-text'
+                }`
               }
             >
               网站管理
@@ -75,7 +87,11 @@ function AuthenticatedLayout() {
             <NavLink
               to="/dashboard/docs"
               className={({ isActive }) =>
-                `rounded-full px-4 py-2 transition ${isActive ? 'bg-white text-slate-900' : 'text-slate-200 hover:bg-white/10'}`
+                `rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-primary text-background'
+                    : 'text-muted hover:bg-surface-hover hover:text-text'
+                }`
               }
             >
               文档管理
@@ -83,7 +99,11 @@ function AuthenticatedLayout() {
             <NavLink
               to="/dashboard/settings"
               className={({ isActive }) =>
-                `rounded-full px-4 py-2 transition ${isActive ? 'bg-white text-slate-900' : 'text-slate-200 hover:bg-white/10'}`
+                `rounded-full px-4 py-2 transition ${
+                  isActive
+                    ? 'bg-primary text-background'
+                    : 'text-muted hover:bg-surface-hover hover:text-text'
+                }`
               }
             >
               设置
@@ -124,7 +144,7 @@ export default function App() {
   }, [init])
 
   if (!initialized) {
-    return <div className="min-h-screen bg-slate-950 px-6 py-10 text-slate-100">加载中...</div>
+    return <div className="min-h-screen bg-background px-6 py-10 text-text transition-colors">加载中...</div>
   }
 
   return (

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -80,7 +80,7 @@ export default class AppErrorBoundary extends Component<
             <button
               type="button"
               onClick={this.handleRefresh}
-              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white transition hover:bg-primary/90"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-background transition hover:bg-primary/90"
             >
               <RefreshCw className="h-4 w-4" aria-hidden />
               <span>刷新页面</span>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -38,28 +38,28 @@ export function AppLayout({
 }: AppLayoutProps) {
   return (
     <div className="space-y-8">
-      <header className="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-8 shadow-lg shadow-slate-950/20">
+      <header className="space-y-6 rounded-3xl border border-border bg-surface p-8 shadow-lg shadow-black/10 transition-colors dark:shadow-black/40">
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div className="space-y-2">
-            <h1 className="text-2xl font-semibold text-white">{title}</h1>
-            {description && <p className="text-sm text-slate-300">{description}</p>}
+            <h1 className="text-2xl font-semibold text-text">{title}</h1>
+            {description && <p className="text-sm text-muted">{description}</p>}
           </div>
           {actions}
         </div>
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center">
           <div className="relative flex-1">
-            <SearchIcon className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <SearchIcon className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
             <input
               value={searchValue}
               onChange={event => onSearchChange(event.target.value)}
               placeholder={searchPlaceholder ?? '搜索'}
-              className="h-12 w-full rounded-full border border-white/10 bg-slate-950/60 pl-12 pr-28 text-sm text-slate-100 shadow-inner shadow-slate-950/40 outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+              className="h-12 w-full rounded-full border border-border bg-surface pl-12 pr-28 text-sm text-text shadow-inner shadow-black/5 outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             />
             {commandPalette && (
               <button
                 type="button"
                 onClick={commandPalette.onOpen}
-                className="absolute right-2 top-1/2 inline-flex -translate-y-1/2 items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-white/40 hover:bg-white/10"
+                className="absolute right-2 top-1/2 inline-flex -translate-y-1/2 items-center gap-1 rounded-full border border-border bg-surface px-3 py-1 text-xs font-semibold text-text transition hover:bg-surface-hover"
               >
                 <CommandIcon className="h-3.5 w-3.5" />
                 <span>Ctrl / Cmd + K</span>
@@ -70,7 +70,7 @@ export function AppLayout({
             <button
               type="button"
               onClick={onCreate}
-              className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-white px-5 text-sm font-semibold text-slate-900 shadow-lg shadow-slate-950/20 transition hover:bg-slate-200"
+              className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-semibold text-background shadow-lg shadow-black/10 transition hover:bg-primary/90 dark:shadow-black/40"
             >
               <PlusIcon className="h-4 w-4" />
               {createLabel}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -88,9 +88,9 @@ export function CommandPalette({ open, onClose, items, onSelect, placeholder }: 
   if (!open) return null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center bg-slate-950/60 px-4 py-24 backdrop-blur">
-      <div className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-slate-900/90 shadow-2xl shadow-slate-950/40 backdrop-blur">
-        <div className="border-b border-white/5 px-6 py-4">
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-background/80 px-4 py-24 backdrop-blur">
+      <div className="w-full max-w-xl overflow-hidden rounded-3xl border border-border bg-surface shadow-2xl shadow-black/30 backdrop-blur">
+        <div className="border-b border-border/60 px-6 py-4">
           <input
             ref={inputRef}
             value={query}
@@ -99,12 +99,12 @@ export function CommandPalette({ open, onClose, items, onSelect, placeholder }: 
               setActiveIndex(0)
             }}
             placeholder={placeholder ?? '搜索条目或执行操作'}
-            className="w-full bg-transparent text-sm text-white outline-none placeholder:text-slate-400"
+            className="w-full bg-transparent text-sm text-text outline-none placeholder:text-muted"
           />
         </div>
         <div className="max-h-80 overflow-y-auto py-2">
           {results.length === 0 ? (
-            <p className="px-6 py-8 text-center text-sm text-slate-400">未找到匹配项</p>
+            <p className="px-6 py-8 text-center text-sm text-muted">未找到匹配项</p>
           ) : (
             <ul className="space-y-1 px-2">
               {results.map((item, index) => (
@@ -118,12 +118,12 @@ export function CommandPalette({ open, onClose, items, onSelect, placeholder }: 
                     className={clsx(
                       'w-full rounded-2xl px-4 py-3 text-left transition',
                       index === activeIndex
-                        ? 'bg-white/10 text-white'
-                        : 'text-slate-200 hover:bg-white/5 hover:text-white',
+                        ? 'bg-primary/20 text-text'
+                        : 'text-muted hover:bg-surface-hover hover:text-text',
                     )}
                   >
                     <p className="text-sm font-medium">{item.title}</p>
-                    {item.subtitle && <p className="text-xs text-slate-400">{item.subtitle}</p>}
+                    {item.subtitle && <p className="text-xs text-muted">{item.subtitle}</p>}
                   </button>
                 </li>
               ))}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -110,7 +110,7 @@ export default function ConfirmDialog({
     if (tone === 'danger') {
       return 'bg-surface text-text border border-border'
     }
-    return 'bg-primary text-white'
+    return 'bg-primary text-background'
   }, [tone])
 
   if (!open || typeof document === 'undefined') {

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -127,12 +127,12 @@ export default function CopyButton({
   }
 
   const buttonClassName = clsx(
-    'inline-flex items-center justify-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40',
+    'inline-flex items-center justify-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50',
     status === 'success'
       ? 'border-emerald-300/70 bg-emerald-300/10 text-emerald-200'
       : status === 'error'
       ? 'border-rose-400/70 bg-rose-400/10 text-rose-200'
-      : 'border-white/20 text-white hover:border-white/40 hover:bg-white/10',
+      : 'border-border text-text hover:bg-surface-hover',
     (disabled || isLoading) && 'pointer-events-none opacity-60',
     className,
   )

--- a/src/components/DetailsDrawer.tsx
+++ b/src/components/DetailsDrawer.tsx
@@ -31,29 +31,29 @@ export function DetailsDrawer({ open, title, description, onClose, footer, child
 
   return (
     <div className="fixed inset-0 z-50 flex">
-      <div className="absolute inset-0 bg-slate-950/70 backdrop-blur" aria-hidden onClick={onClose} />
+      <div className="absolute inset-0 bg-background/80 backdrop-blur" aria-hidden onClick={onClose} />
       <aside
         className={clsx(
-          'relative ml-auto flex h-full w-full flex-col overflow-hidden border-l border-white/10 bg-slate-900/95 text-slate-100 shadow-2xl shadow-slate-950/40 backdrop-blur',
+          'relative ml-auto flex h-full w-full flex-col overflow-hidden border-l border-border bg-surface text-text shadow-2xl shadow-black/40 backdrop-blur',
           width === 'md' ? 'max-w-lg' : 'max-w-2xl',
         )}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'drawer-title' : undefined}
       >
-        <div className="flex items-start justify-between gap-4 border-b border-white/5 px-8 py-6">
+        <div className="flex items-start justify-between gap-4 border-b border-border/60 px-8 py-6">
           <div className="space-y-2">
             {title && (
-              <h2 id="drawer-title" className="text-xl font-semibold text-white">
+              <h2 id="drawer-title" className="text-xl font-semibold text-text">
                 {title}
               </h2>
             )}
-            {description && <p className="text-sm text-slate-300">{description}</p>}
+            {description && <p className="text-sm text-muted">{description}</p>}
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full border border-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition hover:border-white/40 hover:bg-white/10"
+            className="rounded-full border border-border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-text transition hover:bg-surface-hover"
           >
             关闭
           </button>
@@ -61,7 +61,7 @@ export function DetailsDrawer({ open, title, description, onClose, footer, child
         <div ref={firstFocusable} className="flex-1 overflow-y-auto px-8 py-6">
           <div className="space-y-6">{children}</div>
         </div>
-        {footer && <div className="border-t border-white/5 px-8 py-6">{footer}</div>}
+        {footer && <div className="border-t border-border/60 px-8 py-6">{footer}</div>}
       </aside>
     </div>
   )

--- a/src/components/Empty.tsx
+++ b/src/components/Empty.tsx
@@ -12,15 +12,15 @@ type EmptyProps = {
 
 export function Empty({ icon, title, description, actionLabel, onAction, className }: EmptyProps) {
   return (
-    <div className={clsx('flex flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/10 bg-white/5 px-6 py-16 text-center text-slate-300', className)}>
-      {icon && <div className="text-3xl text-white/60">{icon}</div>}
-      <h3 className="text-lg font-semibold text-white">{title}</h3>
-      {description && <p className="max-w-md text-sm text-slate-400">{description}</p>}
+    <div className={clsx('flex flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-border bg-surface px-6 py-16 text-center text-muted', className)}>
+      {icon && <div className="text-3xl text-text/60">{icon}</div>}
+      <h3 className="text-lg font-semibold text-text">{title}</h3>
+      {description && <p className="max-w-md text-sm text-muted">{description}</p>}
       {actionLabel && onAction && (
         <button
           type="button"
           onClick={onAction}
-          className="mt-2 inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+          className="mt-2 inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-background transition hover:bg-primary/90"
         >
           {actionLabel}
         </button>

--- a/src/components/FabTools.tsx
+++ b/src/components/FabTools.tsx
@@ -13,7 +13,7 @@ export default function FabTools() {
 
   return (
     <div className="pointer-events-none fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3">
-      <div className="pointer-events-auto rounded-2xl border border-white/10 bg-slate-900/80 p-4 text-xs text-slate-200 shadow-lg shadow-slate-950/40 backdrop-blur">
+      <div className="pointer-events-auto rounded-2xl border border-border bg-surface/90 p-4 text-xs text-text/80 shadow-lg shadow-black/30 backdrop-blur">
         <IdleLockSelector />
       </div>
       <button
@@ -21,7 +21,7 @@ export default function FabTools() {
         onClick={() => {
           lock()
         }}
-        className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-white px-4 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-slate-950/40 transition hover:bg-slate-200"
+        className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-primary px-4 py-3 text-sm font-semibold text-background shadow-lg shadow-black/20 transition hover:bg-primary/90 dark:shadow-black/50"
       >
         <LockIcon className="h-4 w-4" />
         立即锁定

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -5,5 +5,5 @@ type SkeletonProps = {
 }
 
 export function Skeleton({ className }: SkeletonProps) {
-  return <div className={clsx('animate-pulse rounded-2xl bg-white/5', className)} />
+  return <div className={clsx('animate-pulse rounded-2xl bg-surface-hover', className)} />
 }

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -61,19 +61,19 @@ export function ToastProvider({ children }: { children: ReactNode }) {
           <div
             key={toast.id}
             className={clsx(
-              'pointer-events-auto w-full max-w-sm overflow-hidden rounded-2xl border px-4 py-3 shadow-xl shadow-slate-950/40 backdrop-blur',
+              'pointer-events-auto w-full max-w-sm overflow-hidden rounded-2xl border px-4 py-3 shadow-xl shadow-black/30 backdrop-blur transition-colors',
               VARIANT_STYLES[toast.variant],
             )}
           >
             <div className="flex items-start justify-between gap-3">
               <div className="space-y-1">
                 <p className="text-sm font-semibold">{toast.title}</p>
-                {toast.description && <p className="text-xs text-slate-200/80">{toast.description}</p>}
+                {toast.description && <p className="text-xs text-text/80">{toast.description}</p>}
               </div>
               <button
                 type="button"
                 onClick={() => dismissToast(toast.id)}
-                className="rounded-full border border-white/10 px-2 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/80 transition hover:border-white/40 hover:bg-white/10"
+                className="rounded-full border border-border px-2 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-text/80 transition hover:bg-surface-hover"
               >
                 关闭
               </button>

--- a/src/components/VaultItemCard.tsx
+++ b/src/components/VaultItemCard.tsx
@@ -31,7 +31,7 @@ const BADGE_STYLES: Record<NonNullable<VaultItemBadge['tone']>, string> = {
   info: 'bg-sky-500/10 text-sky-200 border-sky-500/30',
   success: 'bg-emerald-500/10 text-emerald-200 border-emerald-500/30',
   warning: 'bg-amber-500/10 text-amber-200 border-amber-500/30',
-  neutral: 'bg-white/5 text-slate-200 border-white/10',
+  neutral: 'bg-surface-hover text-text border-border',
 }
 
 function formatTimestamp(timestamp?: number) {
@@ -55,18 +55,18 @@ export function VaultItemCard({ title, description, badges, tags, updatedAt, onO
           onOpen()
         }
       }}
-      className="group relative flex flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-left text-sm text-slate-200 shadow-lg shadow-slate-950/10 transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      className="group relative flex flex-col gap-4 rounded-3xl border border-border bg-surface p-6 text-left text-sm text-text shadow-lg shadow-black/10 transition hover:-translate-y-0.5 hover:border-primary/30 hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
     >
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-2">
-          <h3 className="text-lg font-semibold text-white">{title}</h3>
-          {description && <p className="text-sm text-slate-300">{description}</p>}
+          <h3 className="text-lg font-semibold text-text">{title}</h3>
+          {description && <p className="text-sm text-muted">{description}</p>}
           {badges && badges.length > 0 && (
             <div className="flex flex-wrap gap-2">
               {badges.map((badge, index) => (
                 <span
                   key={`${badge.label}-${index}`}
-                  className={clsx('inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium', BADGE_STYLES[badge.tone ?? 'neutral'])}
+                  className={clsx('inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors', BADGE_STYLES[badge.tone ?? 'neutral'])}
                 >
                   {badge.label}
                 </span>
@@ -78,7 +78,7 @@ export function VaultItemCard({ title, description, badges, tags, updatedAt, onO
               {tags.map(tag => (
                 <span
                   key={tag.id}
-                  className="inline-flex items-center rounded-full bg-slate-900/60 px-2.5 py-0.5 text-xs text-slate-300"
+                  className="inline-flex items-center rounded-full bg-surface-hover px-2.5 py-0.5 text-xs text-muted"
                 >
                   #{tag.name}
                 </span>
@@ -96,7 +96,7 @@ export function VaultItemCard({ title, description, badges, tags, updatedAt, onO
                   event.stopPropagation()
                   action.onClick()
                 }}
-                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white opacity-0 transition focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 group-hover:opacity-100 hover:border-white/30 hover:bg-white/20"
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs font-semibold text-text opacity-0 transition focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:opacity-100 hover:bg-surface-hover"
               >
                 {action.icon}
                 <span>{action.label}</span>
@@ -106,7 +106,7 @@ export function VaultItemCard({ title, description, badges, tags, updatedAt, onO
         )}
       </div>
       {updatedAt && (
-        <p className="text-xs text-slate-400">最近更新：{formatTimestamp(updatedAt)}</p>
+        <p className="text-xs text-muted">最近更新：{formatTimestamp(updatedAt)}</p>
       )}
     </div>
   )

--- a/src/features/lock/IdleLock.tsx
+++ b/src/features/lock/IdleLock.tsx
@@ -70,12 +70,12 @@ export function IdleLockSelector() {
   }
 
   return (
-    <label className="space-y-2 text-xs text-slate-200">
-      <span className="text-slate-300">自动锁定</span>
+    <label className="space-y-2 text-xs text-text">
+      <span className="text-muted">自动锁定</span>
       <select
         value={duration === 'off' ? 'off' : String(duration)}
         onChange={event => handleChange(event.target.value)}
-        className="w-full rounded-lg border border-white/10 bg-slate-900/80 px-3 py-2 text-xs text-white outline-none transition focus:border-white/50 focus:bg-slate-900"
+        className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-xs text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
       >
         <option value="off">不自动锁定</option>
         <option value={60_000}>1 分钟</option>

--- a/src/features/lock/LockScreen.tsx
+++ b/src/features/lock/LockScreen.tsx
@@ -40,22 +40,22 @@ export function LockScreen() {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 px-6 py-12">
-      <div className="w-full max-w-sm space-y-6 rounded-2xl border border-white/10 bg-slate-950/80 p-8 shadow-xl shadow-slate-950/40">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/90 px-6 py-12">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl border border-border bg-surface p-8 shadow-xl shadow-black/40">
         <div className="space-y-1 text-center">
-          <h2 className="text-2xl font-semibold text-white">已锁定</h2>
-          <p className="text-sm text-slate-300">{email}</p>
-          <p className="text-sm text-slate-400">请输入密码以继续使用应用</p>
+          <h2 className="text-2xl font-semibold text-text">已锁定</h2>
+          <p className="text-sm text-muted">{email}</p>
+          <p className="text-sm text-muted">请输入密码以继续使用应用</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <label className="space-y-2 text-sm">
-            <span className="text-slate-200">密码</span>
+            <span className="text-text">密码</span>
             <input
               type="password"
               value={password}
               onChange={event => setPassword(event.target.value)}
               autoFocus
-              className="w-full rounded-xl border border-white/20 bg-slate-900/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/60 focus:bg-slate-900"
+              className="w-full rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
               placeholder="请输入密码"
             />
           </label>
@@ -63,7 +63,7 @@ export function LockScreen() {
           <button
             type="submit"
             disabled={submitting}
-            className="inline-flex w-full items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-900 transition hover:bg-slate-200 disabled:opacity-70"
+            className="inline-flex w-full items-center justify-center rounded-full bg-primary px-5 py-3 text-sm font-semibold text-background transition hover:bg-primary/90 disabled:bg-primary/50 disabled:text-background/80"
           >
             {submitting ? '解锁中…' : '解锁'}
           </button>
@@ -73,7 +73,7 @@ export function LockScreen() {
           onClick={() => {
             void logout()
           }}
-          className="block w-full text-center text-xs text-slate-400 transition hover:text-slate-200"
+          className="block w-full text-center text-xs text-muted transition hover:text-text"
         >
           切换账号
         </button>

--- a/src/providers/AppErrorBoundary.tsx
+++ b/src/providers/AppErrorBoundary.tsx
@@ -43,27 +43,27 @@ export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorB
     }
 
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 py-12 text-slate-200">
-        <div className="w-full max-w-lg rounded-3xl border border-white/10 bg-slate-900/70 p-10 shadow-2xl shadow-slate-950/50">
-          <h1 className="text-2xl font-semibold text-white">应用出现错误</h1>
-          <p className="mt-3 text-sm leading-relaxed text-slate-300">
+      <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6 py-12 text-text">
+        <div className="w-full max-w-lg rounded-3xl border border-border bg-surface p-10 shadow-2xl shadow-black/30">
+          <h1 className="text-2xl font-semibold text-text">应用出现错误</h1>
+          <p className="mt-3 text-sm leading-relaxed text-muted">
             很抱歉，应用在运行时遇到了问题。您可以尝试刷新页面重新载入，或返回继续使用。
           </p>
-          <pre className="mt-6 max-h-52 overflow-auto rounded-2xl border border-white/10 bg-black/40 p-4 text-xs leading-relaxed text-red-300">
+          <pre className="mt-6 max-h-52 overflow-auto rounded-2xl border border-border bg-background/80 p-4 text-xs leading-relaxed text-rose-300">
             {error.message}
           </pre>
           <div className="mt-8 flex flex-wrap gap-3">
             <button
               type="button"
               onClick={this.handleReload}
-              className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2.5 text-sm font-semibold text-slate-900 shadow-lg shadow-slate-950/40 transition hover:bg-slate-200"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-background shadow-lg shadow-black/20 transition hover:bg-primary/90"
             >
               刷新页面
             </button>
             <button
               type="button"
               onClick={this.handleReset}
-              className="inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-slate-100 transition hover:border-white/40 hover:bg-white/10"
+              className="inline-flex items-center justify-center rounded-full border border-border px-5 py-2.5 text-sm font-semibold text-text transition hover:bg-surface-hover"
             >
               返回应用
             </button>

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -133,8 +133,8 @@ function ToastViewport({ toasts, onDismiss }: ToastViewportProps) {
           <div
             key={toast.id}
             className={clsx(
-              'pointer-events-auto overflow-hidden rounded-2xl border border-white/10 bg-surface text-text shadow-xl shadow-slate-950/40 backdrop-blur transition',
-              'focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-slate-950 focus-within:outline-none',
+              'pointer-events-auto overflow-hidden rounded-2xl border border-border bg-surface text-text shadow-xl shadow-black/30 backdrop-blur transition',
+              'focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-background focus-within:outline-none focus-within:ring-primary/40',
             )}
           >
             <div className={clsx('h-1 w-full', accentClass)} />

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -67,37 +67,37 @@ export default function Dashboard() {
   return (
     <div className="space-y-10">
       <section className="space-y-3">
-        <h2 className="text-2xl font-semibold text-white">欢迎使用离线管理工具</h2>
-        <p className="text-sm text-slate-300">
+        <h2 className="text-2xl font-semibold text-text">欢迎使用离线管理工具</h2>
+        <p className="text-sm text-muted">
           在这里可以集中管理常用密码、常访问的网站和重要文档。所有数据均保存在浏览器本地 IndexedDB 中，不会上传到服务器。
         </p>
         <div className="grid gap-4 md:grid-cols-3">
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
-            <p className="text-sm text-slate-300">密码条目</p>
-            <p className="mt-2 text-3xl font-semibold text-white">{passwordCount}</p>
+          <div className="rounded-2xl border border-border bg-surface p-5 shadow-sm shadow-black/10 transition-colors dark:shadow-black/30">
+            <p className="text-sm text-muted">密码条目</p>
+            <p className="mt-2 text-3xl font-semibold text-text">{passwordCount}</p>
             <Link
               to="/dashboard/passwords"
-              className="mt-4 inline-flex items-center text-sm font-medium text-sky-300 hover:text-sky-200"
+              className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:text-primary/80"
             >
               管理密码 →
             </Link>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
-            <p className="text-sm text-slate-300">网站收藏</p>
-            <p className="mt-2 text-3xl font-semibold text-white">{siteCount}</p>
+          <div className="rounded-2xl border border-border bg-surface p-5 shadow-sm shadow-black/10 transition-colors dark:shadow-black/30">
+            <p className="text-sm text-muted">网站收藏</p>
+            <p className="mt-2 text-3xl font-semibold text-text">{siteCount}</p>
             <Link
               to="/dashboard/sites"
-              className="mt-4 inline-flex items-center text-sm font-medium text-sky-300 hover:text-sky-200"
+              className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:text-primary/80"
             >
               管理网站 →
             </Link>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
-            <p className="text-sm text-slate-300">文档存档</p>
-            <p className="mt-2 text-3xl font-semibold text-white">{docCount}</p>
+          <div className="rounded-2xl border border-border bg-surface p-5 shadow-sm shadow-black/10 transition-colors dark:shadow-black/30">
+            <p className="text-sm text-muted">文档存档</p>
+            <p className="mt-2 text-3xl font-semibold text-text">{docCount}</p>
             <Link
               to="/dashboard/docs"
-              className="mt-4 inline-flex items-center text-sm font-medium text-sky-300 hover:text-sky-200"
+              className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:text-primary/80"
             >
               管理文档 →
             </Link>
@@ -106,16 +106,16 @@ export default function Dashboard() {
       </section>
 
       <section className="space-y-3">
-        <h3 className="text-lg font-medium text-white">最近更新</h3>
+        <h3 className="text-lg font-medium text-text">最近更新</h3>
         {recent.length === 0 ? (
-          <p className="text-sm text-slate-400">暂无数据，先添加一条密码、网站或文档吧。</p>
+          <p className="text-sm text-muted">暂无数据，先添加一条密码、网站或文档吧。</p>
         ) : (
-          <ul className="divide-y divide-white/5 overflow-hidden rounded-2xl border border-white/10 bg-white/5">
+          <ul className="divide-y divide-border/60 overflow-hidden rounded-2xl border border-border bg-surface">
             {recent.map(entry => (
-              <li key={entry.key} className="flex items-center justify-between px-5 py-4 text-sm text-slate-200">
+              <li key={entry.key} className="flex items-center justify-between px-5 py-4 text-sm text-text">
                 <div>
-                  <p className="font-medium text-white">{entry.title}</p>
-                  <p className="text-xs text-slate-400">
+                  <p className="font-medium text-text">{entry.title}</p>
+                  <p className="text-xs text-muted">
                     {entry.type === 'password' ? '密码条目' : entry.type === 'site' ? '网站收藏' : '文档存档'} ·{' '}
                     {new Date(entry.updatedAt).toLocaleString()}
                   </p>
@@ -128,7 +128,7 @@ export default function Dashboard() {
                       ? '/dashboard/sites'
                       : '/dashboard/docs'
                   }
-                  className="text-xs font-medium text-sky-300 hover:text-sky-200"
+                  className="text-xs font-medium text-primary hover:text-primary/80"
                 >
                   查看
                 </Link>

--- a/src/routes/Docs.tsx
+++ b/src/routes/Docs.tsx
@@ -512,7 +512,7 @@ export default function Docs() {
                         <button
                           type="button"
                           onClick={() => handleCopyLink(linkMeta.url)}
-                          className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+                          className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
                         >
                           <Copy className="h-4 w-4" />
                           复制链接
@@ -520,7 +520,7 @@ export default function Docs() {
                         <button
                           type="button"
                           onClick={() => handleOpenLink(linkMeta.url)}
-                          className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+                          className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
                         >
                           <ExternalLink className="h-4 w-4" />
                           打开链接
@@ -535,7 +535,7 @@ export default function Docs() {
                       <button
                         type="button"
                         onClick={() => handleOpenFile(fileMeta)}
-                        className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+                        className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
                       >
                         <FileText className="h-4 w-4" />
                         打开文件
@@ -545,7 +545,7 @@ export default function Docs() {
                   <button
                     type="button"
                     onClick={() => handleEdit(activeItem)}
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-background transition hover:bg-primary/90"
                   >
                     <Pencil className="h-4 w-4" />
                     编辑
@@ -563,18 +563,18 @@ export default function Docs() {
         }
       >
         {drawerMode === 'view' && activeItem ? (
-          <div className="space-y-4 text-sm text-slate-200">
+          <div className="space-y-4 text-sm text-text">
             <div>
-              <p className="text-xs text-slate-400">描述</p>
-              <p className="mt-1 whitespace-pre-line text-base text-white">{activeItem.description || '未填写'}</p>
+              <p className="text-xs text-muted">描述</p>
+              <p className="mt-1 whitespace-pre-line text-base text-text">{activeItem.description || '未填写'}</p>
             </div>
             {(() => {
               const linkMeta = extractLinkMeta(activeItem.document)
               if (!linkMeta) return null
               return (
                 <div>
-                  <p className="text-xs text-slate-400">在线链接</p>
-                  <p className="mt-1 break-all text-base text-sky-300">{linkMeta.url}</p>
+                  <p className="text-xs text-muted">在线链接</p>
+                  <p className="mt-1 break-all text-base text-primary">{linkMeta.url}</p>
                 </div>
               )
             })()}
@@ -583,47 +583,47 @@ export default function Docs() {
               if (!fileMeta) return null
               return (
                 <div className="space-y-1">
-                  <p className="text-xs text-slate-400">本地文件</p>
-                  <p className="text-base text-white">{fileMeta.name}</p>
-                  <p className="text-xs text-slate-400">类型：{fileMeta.mime} · 大小：{formatSize(fileMeta.size)}</p>
-                  <p className="break-all text-xs text-slate-500">路径：{fileMeta.relPath}</p>
-                  <p className="break-all text-xs text-slate-500">SHA-256：{fileMeta.sha256}</p>
+                  <p className="text-xs text-muted">本地文件</p>
+                  <p className="text-base text-text">{fileMeta.name}</p>
+                  <p className="text-xs text-muted">类型：{fileMeta.mime} · 大小：{formatSize(fileMeta.size)}</p>
+                  <p className="break-all text-xs text-muted/80">路径：{fileMeta.relPath}</p>
+                  <p className="break-all text-xs text-muted/80">SHA-256：{fileMeta.sha256}</p>
                 </div>
               )
             })()}
             <div>
-              <p className="text-xs text-slate-400">最近更新</p>
-              <p className="mt-1 text-base text-white">
+              <p className="text-xs text-muted">最近更新</p>
+              <p className="mt-1 text-base text-text">
                 {activeItem.updatedAt ? new Date(activeItem.updatedAt).toLocaleString() : '未知'}
               </p>
             </div>
           </div>
         ) : (
-          <form className="space-y-5 text-sm text-slate-200" onSubmit={handleSubmit}>
+          <form className="space-y-5 text-sm text-text" onSubmit={handleSubmit}>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">标题</span>
+              <span className="text-xs uppercase tracking-wide text-muted">标题</span>
               <input
                 value={draft.title}
                 onChange={event => setDraft(prev => ({ ...prev, title: event.target.value }))}
                 required
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="例如：项目计划"
               />
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">在线链接</span>
+              <span className="text-xs uppercase tracking-wide text-muted">在线链接</span>
               <input
                 value={draft.url}
                 onChange={event => setDraft(prev => ({ ...prev, url: event.target.value }))}
                 type="url"
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="https://docs.example.com"
               />
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">上传文件</span>
-              <input type="file" onChange={handleFileChange} className="block w-full text-sm text-slate-200" />
-              <p className="text-xs text-slate-400">
+              <span className="text-xs uppercase tracking-wide text-muted">上传文件</span>
+              <input type="file" onChange={handleFileChange} className="block w-full text-sm text-text" />
+              <p className="text-xs text-muted">
                 {draft.file
                   ? `已选择：${draft.file.name}`
                   : extractFileMeta(activeItem?.document)
@@ -634,19 +634,19 @@ export default function Docs() {
                 <button
                   type="button"
                   onClick={() => setDraft(prev => ({ ...prev, file: null }))}
-                  className="text-xs text-slate-300 underline"
+                  className="text-xs text-muted underline"
                 >
                   清除已选文件
                 </button>
               )}
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">备注</span>
+              <span className="text-xs uppercase tracking-wide text-muted">备注</span>
               <textarea
                 value={draft.description}
                 onChange={event => setDraft(prev => ({ ...prev, description: event.target.value }))}
                 rows={4}
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="记录文档用途或关键说明"
               />
             </label>
@@ -655,14 +655,14 @@ export default function Docs() {
               <button
                 type="button"
                 onClick={closeDrawer}
-                className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10"
+                className="inline-flex items-center justify-center rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
               >
                 取消
               </button>
               <button
                 type="submit"
                 disabled={submitting}
-                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-70"
+                className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-background transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50 disabled:text-background/80"
               >
                 {submitting ? '保存中…' : '保存'}
               </button>

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -26,16 +26,16 @@ export default function Login() {
   return (
     <div className="space-y-8">
       <div className="space-y-2 text-center">
-        <h1 className="text-3xl font-semibold text-white">邮箱登录</h1>
-        <p className="text-sm text-slate-300">输入邮箱与密码登录，所有数据仅保存在本地设备。</p>
+        <h1 className="text-3xl font-semibold text-text">邮箱登录</h1>
+        <p className="text-sm text-muted">输入邮箱与密码登录，所有数据仅保存在本地设备。</p>
       </div>
 
       <form
         onSubmit={handleSubmit}
-        className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-8 shadow-lg shadow-slate-950/20"
+        className="space-y-6 rounded-2xl border border-border bg-surface/90 p-8 shadow-lg shadow-black/10 transition-colors dark:shadow-black/40"
       >
         <div className="space-y-2 text-left">
-          <label htmlFor="email" className="text-sm font-medium text-white">
+          <label htmlFor="email" className="text-sm font-medium text-text">
             邮箱
           </label>
           <input
@@ -45,13 +45,13 @@ export default function Login() {
             autoComplete="email"
             value={email}
             onChange={event => setEmail(event.target.value)}
-            className="w-full rounded-xl border border-white/20 bg-slate-950/40 px-4 py-3 text-sm text-white outline-none transition focus:border-white/60 focus:bg-slate-950/60"
+            className="w-full rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             placeholder="you@example.com"
           />
         </div>
 
         <div className="space-y-2 text-left">
-          <label htmlFor="password" className="text-sm font-medium text-white">
+          <label htmlFor="password" className="text-sm font-medium text-text">
             密码
           </label>
           <input
@@ -61,7 +61,7 @@ export default function Login() {
             autoComplete="current-password"
             value={password}
             onChange={event => setPassword(event.target.value)}
-            className="w-full rounded-xl border border-white/20 bg-slate-950/40 px-4 py-3 text-sm text-white outline-none transition focus:border-white/60 focus:bg-slate-950/60"
+            className="w-full rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             placeholder="请输入登录密码"
           />
         </div>
@@ -71,15 +71,15 @@ export default function Login() {
         <button
           type="submit"
           disabled={loading}
-          className="inline-flex w-full items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:bg-white/40 disabled:text-slate-700/70"
+          className="inline-flex w-full items-center justify-center rounded-full bg-primary px-5 py-3 text-sm font-semibold text-background transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50 disabled:text-background/80"
         >
           {loading ? '登录中…' : '登录'}
         </button>
       </form>
 
-      <p className="text-center text-sm text-slate-300">
+      <p className="text-center text-sm text-muted">
         还没有账号？{' '}
-        <Link to="/register" className="font-medium text-white transition hover:text-slate-200">
+        <Link to="/register" className="font-medium text-text transition hover:text-text/80">
           立即注册
         </Link>
       </p>

--- a/src/routes/Passwords.tsx
+++ b/src/routes/Passwords.tsx
@@ -388,7 +388,7 @@ export default function Passwords() {
                   <button
                     type="button"
                     onClick={() => handleCopyPassword(activeItem)}
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
                   >
                     <Copy className="h-4 w-4" />
                     复制密码
@@ -397,7 +397,7 @@ export default function Passwords() {
                     <button
                       type="button"
                       onClick={() => handleOpenUrl(activeItem)}
-                      className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+                      className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
                     >
                       <ExternalLink className="h-4 w-4" />
                       打开链接
@@ -406,7 +406,7 @@ export default function Passwords() {
                   <button
                     type="button"
                     onClick={() => handleEdit(activeItem)}
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-background transition hover:bg-primary/90"
                   >
                     <Pencil className="h-4 w-4" />
                     编辑
@@ -424,62 +424,62 @@ export default function Passwords() {
         }
       >
         {drawerMode === 'view' && activeItem ? (
-          <div className="space-y-4 text-sm text-slate-200">
+          <div className="space-y-4 text-sm text-text">
             <div>
-              <p className="text-xs text-slate-400">用户名</p>
-              <p className="mt-1 text-base text-white">{activeItem.username || '未填写'}</p>
+              <p className="text-xs text-muted">用户名</p>
+              <p className="mt-1 text-base text-text">{activeItem.username || '未填写'}</p>
             </div>
             <div>
-              <p className="text-xs text-slate-400">关联网址</p>
-              <p className="mt-1 break-all text-base text-sky-300">{activeItem.url || '未填写'}</p>
+              <p className="text-xs text-muted">关联网址</p>
+              <p className="mt-1 break-all text-base text-primary">{activeItem.url || '未填写'}</p>
             </div>
             <div>
-              <p className="text-xs text-slate-400">最近更新</p>
-              <p className="mt-1 text-base text-white">
+              <p className="text-xs text-muted">最近更新</p>
+              <p className="mt-1 text-base text-text">
                 {activeItem.updatedAt ? new Date(activeItem.updatedAt).toLocaleString() : '未知'}
               </p>
             </div>
           </div>
         ) : (
-          <form className="space-y-5 text-sm text-slate-200" onSubmit={handleSubmit}>
+          <form className="space-y-5 text-sm text-text" onSubmit={handleSubmit}>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">名称</span>
+              <span className="text-xs uppercase tracking-wide text-muted">名称</span>
               <input
                 value={draft.title}
                 onChange={event => setDraft(prev => ({ ...prev, title: event.target.value }))}
                 required
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="例如：邮箱账号"
               />
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">用户名</span>
+              <span className="text-xs uppercase tracking-wide text-muted">用户名</span>
               <input
                 value={draft.username}
                 onChange={event => setDraft(prev => ({ ...prev, username: event.target.value }))}
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="可选"
               />
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">
+              <span className="text-xs uppercase tracking-wide text-muted">
                 {drawerMode === 'edit' ? '新密码（留空保持不变）' : '密码'}
               </span>
               <input
                 value={draft.password}
                 onChange={event => setDraft(prev => ({ ...prev, password: event.target.value }))}
                 type="password"
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder={drawerMode === 'edit' ? '如需更新密码，请在此输入' : '请输入密码'}
               />
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">关联网址</span>
+              <span className="text-xs uppercase tracking-wide text-muted">关联网址</span>
               <input
                 value={draft.url}
                 onChange={event => setDraft(prev => ({ ...prev, url: event.target.value }))}
                 type="url"
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="https://example.com"
               />
             </label>
@@ -488,14 +488,14 @@ export default function Passwords() {
               <button
                 type="button"
                 onClick={closeDrawer}
-                className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10"
+                className="inline-flex items-center justify-center rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
               >
                 取消
               </button>
               <button
                 type="submit"
                 disabled={submitting}
-                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-70"
+                className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-background transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50 disabled:text-background/80"
               >
                 {submitting ? '保存中…' : '保存'}
               </button>

--- a/src/routes/Register.tsx
+++ b/src/routes/Register.tsx
@@ -31,16 +31,16 @@ export default function Register() {
   return (
     <div className="space-y-8">
       <div className="space-y-2 text-center">
-        <h1 className="text-3xl font-semibold text-white">创建新账户</h1>
-        <p className="text-sm text-slate-300">注册后即可离线管理密码、网站与文档。</p>
+        <h1 className="text-3xl font-semibold text-text">创建新账户</h1>
+        <p className="text-sm text-muted">注册后即可离线管理密码、网站与文档。</p>
       </div>
 
       <form
         onSubmit={handleSubmit}
-        className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-8 shadow-lg shadow-slate-950/20"
+        className="space-y-6 rounded-2xl border border-border bg-surface/90 p-8 shadow-lg shadow-black/10 transition-colors dark:shadow-black/40"
       >
         <div className="space-y-2 text-left">
-          <label htmlFor="email" className="text-sm font-medium text-white">
+          <label htmlFor="email" className="text-sm font-medium text-text">
             邮箱
           </label>
           <input
@@ -50,13 +50,13 @@ export default function Register() {
             autoComplete="email"
             value={email}
             onChange={event => setEmail(event.target.value)}
-            className="w-full rounded-xl border border-white/20 bg-slate-950/40 px-4 py-3 text-sm text-white outline-none transition focus:border-white/60 focus:bg-slate-950/60"
+            className="w-full rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             placeholder="you@example.com"
           />
         </div>
 
         <div className="space-y-2 text-left">
-          <label htmlFor="password" className="text-sm font-medium text-white">
+          <label htmlFor="password" className="text-sm font-medium text-text">
             登录密码
           </label>
           <input
@@ -66,13 +66,13 @@ export default function Register() {
             autoComplete="new-password"
             value={password}
             onChange={event => setPassword(event.target.value)}
-            className="w-full rounded-xl border border-white/20 bg-slate-950/40 px-4 py-3 text-sm text-white outline-none transition focus:border-white/60 focus:bg-slate-950/60"
+            className="w-full rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             placeholder="不少于 6 位"
           />
         </div>
 
         <div className="space-y-2 text-left">
-          <label htmlFor="confirm" className="text-sm font-medium text-white">
+          <label htmlFor="confirm" className="text-sm font-medium text-text">
             确认密码
           </label>
           <input
@@ -81,7 +81,7 @@ export default function Register() {
             required
             value={confirm}
             onChange={event => setConfirm(event.target.value)}
-            className="w-full rounded-xl border border-white/20 bg-slate-950/40 px-4 py-3 text-sm text-white outline-none transition focus:border-white/60 focus:bg-slate-950/60"
+            className="w-full rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             placeholder="再次输入密码"
           />
         </div>
@@ -91,15 +91,15 @@ export default function Register() {
         <button
           type="submit"
           disabled={loading}
-          className="inline-flex w-full items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:bg-white/40 disabled:text-slate-700/70"
+          className="inline-flex w-full items-center justify-center rounded-full bg-primary px-5 py-3 text-sm font-semibold text-background transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50 disabled:text-background/80"
         >
           {loading ? '注册中…' : '注册'}
         </button>
       </form>
 
-      <p className="text-center text-sm text-slate-300">
+      <p className="text-center text-sm text-muted">
         已有账号？{' '}
-        <Link to="/login" className="font-medium text-white transition hover:text-slate-200">
+        <Link to="/login" className="font-medium text-text transition hover:text-text/80">
           去登录
         </Link>
       </p>

--- a/src/routes/Sites.tsx
+++ b/src/routes/Sites.tsx
@@ -345,7 +345,7 @@ export default function Sites() {
                   <button
                     type="button"
                     onClick={() => handleCopyUrl(activeItem)}
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
                   >
                     <Copy className="h-4 w-4" />
                     复制链接
@@ -353,7 +353,7 @@ export default function Sites() {
                   <button
                     type="button"
                     onClick={() => handleOpenUrl(activeItem)}
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/20"
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
                   >
                     <ExternalLink className="h-4 w-4" />
                     打开链接
@@ -361,7 +361,7 @@ export default function Sites() {
                   <button
                     type="button"
                     onClick={() => handleEdit(activeItem)}
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-background transition hover:bg-primary/90"
                   >
                     <Pencil className="h-4 w-4" />
                     编辑
@@ -379,52 +379,52 @@ export default function Sites() {
         }
       >
         {drawerMode === 'view' && activeItem ? (
-          <div className="space-y-4 text-sm text-slate-200">
+          <div className="space-y-4 text-sm text-text">
             <div>
-              <p className="text-xs text-slate-400">链接地址</p>
-              <p className="mt-1 break-all text-base text-sky-300">{activeItem.url}</p>
+              <p className="text-xs text-muted">链接地址</p>
+              <p className="mt-1 break-all text-base text-primary">{activeItem.url}</p>
             </div>
             <div>
-              <p className="text-xs text-slate-400">简介</p>
-              <p className="mt-1 whitespace-pre-line text-base text-white">{activeItem.description || '未填写'}</p>
+              <p className="text-xs text-muted">简介</p>
+              <p className="mt-1 whitespace-pre-line text-base text-text">{activeItem.description || '未填写'}</p>
             </div>
             <div>
-              <p className="text-xs text-slate-400">最近更新</p>
-              <p className="mt-1 text-base text-white">
+              <p className="text-xs text-muted">最近更新</p>
+              <p className="mt-1 text-base text-text">
                 {activeItem.updatedAt ? new Date(activeItem.updatedAt).toLocaleString() : '未知'}
               </p>
             </div>
           </div>
         ) : (
-          <form className="space-y-5 text-sm text-slate-200" onSubmit={handleSubmit}>
+          <form className="space-y-5 text-sm text-text" onSubmit={handleSubmit}>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">名称</span>
+              <span className="text-xs uppercase tracking-wide text-muted">名称</span>
               <input
                 value={draft.title}
                 onChange={event => setDraft(prev => ({ ...prev, title: event.target.value }))}
                 required
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="例如：公司后台"
               />
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">链接</span>
+              <span className="text-xs uppercase tracking-wide text-muted">链接</span>
               <input
                 value={draft.url}
                 onChange={event => setDraft(prev => ({ ...prev, url: event.target.value }))}
                 required
                 type="url"
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="https://example.com"
               />
             </label>
             <label className="block space-y-2">
-              <span className="text-xs uppercase tracking-wide text-slate-400">简介</span>
+              <span className="text-xs uppercase tracking-wide text-muted">简介</span>
               <textarea
                 value={draft.description}
                 onChange={event => setDraft(prev => ({ ...prev, description: event.target.value }))}
                 rows={4}
-                className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white outline-none transition focus:border-white/40 focus:bg-slate-950/80"
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="可记录登录说明或备注"
               />
             </label>
@@ -433,14 +433,14 @@ export default function Sites() {
               <button
                 type="button"
                 onClick={closeDrawer}
-                className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10"
+                className="inline-flex items-center justify-center rounded-full border border-border bg-surface px-4 py-2 text-sm font-semibold text-text transition hover:bg-surface-hover"
               >
                 取消
               </button>
               <button
                 type="submit"
                 disabled={submitting}
-                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-70"
+                className="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-background transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50 disabled:text-background/80"
               >
                 {submitting ? '保存中…' : '保存'}
               </button>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,10 +1,17 @@
 /* 允许通过 data-theme 覆盖（默认按 light/dark 两套） */
 :root[data-theme="light"] {
-  --bg: #f7f8fb;
-  --panel: #ffffff;
-  --text: #1a1c24;
-  --muted: #6b7280;
-  --primary: #5b8cff;
+  --color-background: 247 248 251;
+  --color-surface: 255 255 255;
+  --color-surface-hover: 240 243 250;
+  --color-border: 226 232 240;
+  --color-text: 26 28 36;
+  --color-text-muted: 107 114 128;
+  --color-primary: 91 140 255;
+  --bg: rgb(var(--color-background));
+  --panel: rgb(var(--color-surface));
+  --text: rgb(var(--color-text));
+  --muted: rgb(var(--color-text-muted));
+  --primary: rgb(var(--color-primary));
   --destructive: #f06a6a;
   --ring: #88a7ff;
   --radius: 12px;
@@ -15,11 +22,18 @@
   --space-4: 24px;
 }
 :root[data-theme="dark"] {
-  --bg: #0b0c10;
-  --panel: #111318;
-  --text: #e6e8ef;
-  --muted: #8b93a7;
-  --primary: #5b8cff;
+  --color-background: 11 12 16;
+  --color-surface: 17 19 24;
+  --color-surface-hover: 26 29 36;
+  --color-border: 36 40 50;
+  --color-text: 230 232 239;
+  --color-text-muted: 139 147 167;
+  --color-primary: 91 140 255;
+  --bg: rgb(var(--color-background));
+  --panel: rgb(var(--color-surface));
+  --text: rgb(var(--color-text));
+  --muted: rgb(var(--color-text-muted));
+  --primary: rgb(var(--color-primary));
   --destructive: #f06a6a;
   --ring: #88a7ff;
   --radius: 12px;
@@ -32,11 +46,18 @@
 
 :root {
   color-scheme: light dark;
-  --bg: #f7f8fb;
-  --panel: #ffffff;
-  --text: #1a1c24;
-  --muted: #6b7280;
-  --primary: #5b8cff;
+  --color-background: 247 248 251;
+  --color-surface: 255 255 255;
+  --color-surface-hover: 240 243 250;
+  --color-border: 226 232 240;
+  --color-text: 26 28 36;
+  --color-text-muted: 107 114 128;
+  --color-primary: 91 140 255;
+  --bg: rgb(var(--color-background));
+  --panel: rgb(var(--color-surface));
+  --text: rgb(var(--color-text));
+  --muted: rgb(var(--color-text-muted));
+  --primary: rgb(var(--color-primary));
   --destructive: #f06a6a;
   --ring: #88a7ff;
   --radius: 12px;
@@ -60,8 +81,8 @@ body,
 
 body {
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
+  background: rgb(var(--color-background));
+  color: rgb(var(--color-text));
   font-family: var(--font-sans);
   font-size: 14px;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- expose rgb-based background, surface, border, text and primary tokens for light and dark themes
- refactor application shells, forms and shared components to consume the new theme utilities instead of fixed slate/white colors
- update overlays and toast/palette experiences to honor the theme palette

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cec95bbc6083318d62460c935c56e3