### PR TITLE
Show draft titles while editing items

### DIFF
--- a/src/routes/Docs.tsx
+++ b/src/routes/Docs.tsx
@@ -395,6 +395,8 @@ export default function Docs() {
 
   /* --------------------------------- 渲染 -------------------------------- */
 
+  const editingTitle = draft.title.trim() || activeItem?.title || ''
+
   return (
     <AppLayout
       title="文档管理"
@@ -492,7 +494,9 @@ export default function Docs() {
           drawerMode === 'create'
             ? '新增文档'
             : drawerMode === 'edit'
-            ? `编辑文档：${activeItem?.title ?? ''}`
+            ? editingTitle
+              ? `编辑文档：${editingTitle}`
+              : '编辑文档'
             : activeItem?.title ?? '查看文档'
         }
         description={

--- a/src/routes/Passwords.tsx
+++ b/src/routes/Passwords.tsx
@@ -293,6 +293,8 @@ export default function Passwords() {
     },
   })
 
+  const editingTitle = draft.title.trim() || activeItem?.title || ''
+
   return (
     <AppLayout
       title="密码库"
@@ -373,7 +375,9 @@ export default function Passwords() {
           drawerMode === 'create'
             ? '新增密码'
             : drawerMode === 'edit'
-            ? `编辑密码：${activeItem?.title ?? ''}`
+            ? editingTitle
+              ? `编辑密码：${editingTitle}`
+              : '编辑密码'
             : activeItem?.title ?? '查看密码'
         }
         description={

--- a/src/routes/Sites.tsx
+++ b/src/routes/Sites.tsx
@@ -252,6 +252,8 @@ export default function Sites() {
     },
   })
 
+  const editingTitle = draft.title.trim() || activeItem?.title || ''
+
   return (
     <AppLayout
       title="网站管理"
@@ -330,7 +332,9 @@ export default function Sites() {
           drawerMode === 'create'
             ? '新增网站'
             : drawerMode === 'edit'
-            ? `编辑网站：${activeItem?.title ?? ''}`
+            ? editingTitle
+              ? `编辑网站：${editingTitle}`
+              : '编辑网站'
             : activeItem?.title ?? '查看网站'
         }
         description={


### PR DESCRIPTION
## Summary
- derive an editing title helper for site, password, and document drawers
- render edit headings from the live draft value with a fallback label when empty

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceeb9626cc8331add59e7188d19314