### PR TITLE
feat: add user profile management

### DIFF
--- a/src/components/AvatarUploader.tsx
+++ b/src/components/AvatarUploader.tsx
@@ -1,0 +1,181 @@
+import clsx from 'clsx'
+import { useEffect, useRef, useState, type ChangeEventHandler } from 'react'
+import type { UserAvatarMeta } from '../stores/database'
+
+const MAX_DIMENSION = 256
+const MAX_FILE_SIZE = 2 * 1024 * 1024
+
+export type AvatarUploaderProps = {
+  value: UserAvatarMeta | null
+  onChange: (value: UserAvatarMeta | null) => void
+  onError?: (message: string) => void
+  disabled?: boolean
+}
+
+function readFileAsDataUrl(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '')
+    reader.onerror = () => reject(new Error('读取文件失败'))
+    reader.readAsDataURL(file)
+  })
+}
+
+async function loadImage(dataUrl: string) {
+  const image = new Image()
+  image.src = dataUrl
+  image.crossOrigin = 'anonymous'
+  await new Promise((resolve, reject) => {
+    image.onload = resolve
+    image.onerror = reject
+  })
+  return image
+}
+
+function calculateSize(width: number, height: number) {
+  const maxSide = Math.max(width, height)
+  if (maxSide <= MAX_DIMENSION) {
+    return { width: Math.round(width), height: Math.round(height) }
+  }
+  const scale = MAX_DIMENSION / maxSide
+  return { width: Math.round(width * scale), height: Math.round(height * scale) }
+}
+
+async function processAvatar(file: File): Promise<UserAvatarMeta> {
+  const originalDataUrl = await readFileAsDataUrl(file)
+  const image = await loadImage(originalDataUrl)
+  const { width, height } = calculateSize(image.width, image.height)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = width || MAX_DIMENSION
+  canvas.height = height || MAX_DIMENSION
+  const context = canvas.getContext('2d')
+  if (!context) {
+    throw new Error('当前环境不支持头像处理')
+  }
+  context.clearRect(0, 0, canvas.width, canvas.height)
+  context.drawImage(image, 0, 0, canvas.width, canvas.height)
+
+  const blob: Blob = await new Promise((resolve, reject) => {
+    canvas.toBlob(blobResult => {
+      if (blobResult) resolve(blobResult)
+      else reject(new Error('头像压缩失败'))
+    }, 'image/png', 0.92)
+  })
+
+  const dataUrl = await readFileAsDataUrl(blob)
+
+  return {
+    dataUrl,
+    mime: blob.type || 'image/png',
+    size: blob.size,
+    width: canvas.width,
+    height: canvas.height,
+    updatedAt: Date.now(),
+  }
+}
+
+export function AvatarUploader({ value, onChange, onError, disabled }: AvatarUploaderProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [preview, setPreview] = useState<string | null>(value?.dataUrl ?? null)
+  const [isProcessing, setIsProcessing] = useState(false)
+
+  useEffect(() => {
+    setPreview(value?.dataUrl ?? null)
+  }, [value?.dataUrl])
+
+  const handlePick = () => {
+    if (disabled) return
+    inputRef.current?.click()
+  }
+
+  const handleFileChange: ChangeEventHandler<HTMLInputElement> = async event => {
+    if (disabled) return
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+
+    if (!file.type.startsWith('image/')) {
+      onError?.('请选择图片文件作为头像')
+      return
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      onError?.('图片体积过大，请选择 2MB 以内的文件')
+      return
+    }
+
+    try {
+      setIsProcessing(true)
+      const meta = await processAvatar(file)
+      setPreview(meta.dataUrl)
+      onChange(meta)
+    } catch (error) {
+      console.error('Failed to process avatar', error)
+      onError?.('头像处理失败，请尝试其他图片')
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  const handleRemove = () => {
+    if (disabled) return
+    setPreview(null)
+    onChange(null)
+  }
+
+  return (
+    <div className={clsx('flex flex-col gap-3 sm:flex-row sm:items-center', disabled && 'opacity-60')}>
+      <div className="relative h-24 w-24 overflow-hidden rounded-full border border-border/60 bg-surface shadow-sm">
+        {preview ? (
+          <img src={preview} alt="头像预览" className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-muted">无头像</div>
+        )}
+        {isProcessing ? (
+          <div className="absolute inset-0 grid place-items-center bg-black/40 text-xs font-medium text-background">
+            处理中…
+          </div>
+        ) : null}
+      </div>
+      <div className="flex flex-1 flex-col gap-2 text-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handlePick}
+            disabled={disabled || isProcessing}
+            className={clsx(
+              'inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-background shadow-sm transition',
+              'hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60',
+            )}
+          >
+            选择图片
+          </button>
+          <button
+            type="button"
+            onClick={handleRemove}
+            disabled={disabled || isProcessing || !preview}
+            className={clsx(
+              'inline-flex items-center rounded-lg border border-border/60 px-4 py-2 text-sm font-medium text-text transition',
+              'hover:border-border hover:bg-surface/80 disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          >
+            移除头像
+          </button>
+        </div>
+        <p className="text-xs leading-relaxed text-muted">
+          支持 JPG/PNG，最大 2MB，将自动压缩至不超过 256×256 像素。
+        </p>
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        disabled={disabled}
+        onChange={handleFileChange}
+        className="hidden"
+      />
+    </div>
+  )
+}
+
+export default AvatarUploader

--- a/src/lib/sensitive-words.ts
+++ b/src/lib/sensitive-words.ts
@@ -1,0 +1,49 @@
+const DEFAULT_SENSITIVE_RULES: (string | RegExp)[] = [
+  'admin',
+  'administrator',
+  '管理员',
+  '官方',
+  /\b(root|system)\b/i,
+]
+
+function escapeRegExp(input: string) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function normalizeInput(input: string) {
+  return input
+    .normalize('NFKC')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function detectSensitiveWords(
+  value: string,
+  rules: (string | RegExp)[] = DEFAULT_SENSITIVE_RULES,
+): string[] {
+  const normalized = normalizeInput(value)
+  if (!normalized) return []
+  const matches = new Set<string>()
+
+  for (const rule of rules) {
+    if (typeof rule === 'string') {
+      const keyword = rule.trim()
+      if (!keyword) continue
+      const pattern = new RegExp(escapeRegExp(keyword), 'i')
+      if (pattern.test(normalized)) {
+        matches.add(keyword)
+      }
+    } else if (rule instanceof RegExp) {
+      const result = normalized.match(rule)
+      if (result && result[0]) {
+        matches.add(result[0])
+      }
+    }
+  }
+
+  return Array.from(matches)
+}
+
+export function hasSensitiveWords(value: string, rules?: (string | RegExp)[]) {
+  return detectSensitiveWords(value, rules).length > 0
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { deriveKey } from '../lib/crypto'
-import { db, type UserRecord } from './database'
+import { detectSensitiveWords } from '../lib/sensitive-words'
+import { db, type UserAvatarMeta, type UserRecord } from './database'
 
 export const SESSION_STORAGE_KEY = 'pms-web-session'
 
@@ -19,14 +20,32 @@ function fromBase64(str: string) {
 
 type AuthResult = { success: boolean; message?: string }
 
+const MIN_DISPLAY_NAME_LENGTH = 2
+const MAX_DISPLAY_NAME_LENGTH = 30
+const MAX_AVATAR_SIZE = 1024 * 1024 * 2
+
+export type UserProfile = {
+  email: string
+  displayName: string
+  avatar: UserAvatarMeta | null
+}
+
+type ProfileUpdatePayload = {
+  displayName: string
+  avatar: UserAvatarMeta | null
+}
+
 type AuthState = {
   email: string | null
   encryptionKey: Uint8Array | null
   initialized: boolean
+  profile: UserProfile | null
   init: () => Promise<void>
   register: (email: string, password: string) => Promise<AuthResult>
   login: (email: string, password: string) => Promise<AuthResult>
   logout: () => Promise<void>
+  loadProfile: () => Promise<UserProfile | null>
+  updateProfile: (payload: ProfileUpdatePayload) => Promise<AuthResult>
 }
 
 function saveSession(email: string, key: Uint8Array) {
@@ -70,22 +89,89 @@ function clearSession() {
   }
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+function normalizeDisplayName(value: string) {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function fallbackDisplayName(email: string, displayName?: string) {
+  const normalized = normalizeDisplayName(displayName ?? '')
+  if (normalized) return normalized
+  const prefix = email.split('@')[0]?.trim()
+  return prefix || email || '用户'
+}
+
+function mapRecordToProfile(record: UserRecord): UserProfile {
+  return {
+    email: record.email,
+    displayName: fallbackDisplayName(record.email, record.displayName),
+    avatar: record.avatar ?? null,
+  }
+}
+
+type AvatarValidationResult =
+  | { ok: true; value: UserAvatarMeta | null }
+  | { ok: false; message: string }
+
+function validateAvatarMeta(meta: UserAvatarMeta | null): AvatarValidationResult {
+  if (!meta) return { ok: true, value: null }
+  if (typeof meta.dataUrl !== 'string' || !meta.dataUrl.startsWith('data:image/')) {
+    return { ok: false, message: '仅支持图片格式的头像' }
+  }
+  const size = Number(meta.size)
+  if (!Number.isFinite(size) || size <= 0) {
+    return { ok: false, message: '头像数据无效' }
+  }
+  if (size > MAX_AVATAR_SIZE) {
+    return { ok: false, message: '头像文件过大（需小于 2MB）' }
+  }
+  const width = Number(meta.width)
+  const height = Number(meta.height)
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return { ok: false, message: '头像尺寸无效' }
+  }
+  const mime = typeof meta.mime === 'string' && meta.mime ? meta.mime : 'image/png'
+  const updatedAt = Number(meta.updatedAt)
+  return {
+    ok: true,
+    value: {
+      dataUrl: meta.dataUrl,
+      mime,
+      size,
+      width,
+      height,
+      updatedAt: Number.isFinite(updatedAt) ? updatedAt : Date.now(),
+    },
+  }
+}
+
+export const useAuthStore = create<AuthState>((set, get) => ({
   email: null,
   encryptionKey: null,
   initialized: false,
+  profile: null,
   async init() {
     try {
       await db.open()
       const session = restoreSession()
       if (session) {
-        set({ email: session.email, encryptionKey: session.key, initialized: true })
+        const record = await db.users.get(session.email)
+        if (record) {
+          set({
+            email: session.email,
+            encryptionKey: session.key,
+            profile: mapRecordToProfile(record),
+            initialized: true,
+          })
+        } else {
+          clearSession()
+          set({ email: null, encryptionKey: null, profile: null, initialized: true })
+        }
       } else {
-        set({ email: null, encryptionKey: null, initialized: true })
+        set({ email: null, encryptionKey: null, profile: null, initialized: true })
       }
     } catch (error) {
       console.error('Failed to initialize auth store', error)
-      set({ email: null, encryptionKey: null, initialized: true })
+      set({ email: null, encryptionKey: null, profile: null, initialized: true })
     }
   },
   async register(rawEmail, password) {
@@ -107,12 +193,14 @@ export const useAuthStore = create<AuthState>((set) => ({
       email,
       salt: toBase64(saltBytes),
       keyHash: toBase64(key),
+      displayName: fallbackDisplayName(email),
+      avatar: null,
       createdAt: now,
       updatedAt: now,
     }
     await db.users.put(record)
     saveSession(email, key)
-    set({ email, encryptionKey: key })
+    set({ email, encryptionKey: key, profile: mapRecordToProfile(record) })
     return { success: true }
   },
   async login(rawEmail, password) {
@@ -131,11 +219,74 @@ export const useAuthStore = create<AuthState>((set) => ({
       return { success: false, message: '密码错误' }
     }
     saveSession(email, key)
-    set({ email, encryptionKey: key })
+    set({ email, encryptionKey: key, profile: mapRecordToProfile(record) })
     return { success: true }
   },
   async logout() {
     clearSession()
-    set({ email: null, encryptionKey: null })
+    set({ email: null, encryptionKey: null, profile: null })
+  },
+  async loadProfile() {
+    const { email } = get()
+    if (!email) return null
+    try {
+      const record = await db.users.get(email)
+      if (!record) {
+        set({ profile: null })
+        return null
+      }
+      const profile = mapRecordToProfile(record)
+      set({ profile })
+      return profile
+    } catch (error) {
+      console.error('Failed to load user profile', error)
+      return null
+    }
+  },
+  async updateProfile(payload) {
+    const { email } = get()
+    if (!email) {
+      return { success: false, message: '请先登录后再更新资料' }
+    }
+    const normalizedName = normalizeDisplayName(payload.displayName)
+    if (!normalizedName) {
+      return { success: false, message: '请输入用户名' }
+    }
+    if (normalizedName.length < MIN_DISPLAY_NAME_LENGTH) {
+      return { success: false, message: `用户名至少需要 ${MIN_DISPLAY_NAME_LENGTH} 个字符` }
+    }
+    if (normalizedName.length > MAX_DISPLAY_NAME_LENGTH) {
+      return { success: false, message: `用户名不能超过 ${MAX_DISPLAY_NAME_LENGTH} 个字符` }
+    }
+    const banned = detectSensitiveWords(normalizedName)
+    if (banned.length > 0) {
+      return { success: false, message: `用户名包含敏感词：${banned.join('、')}` }
+    }
+    const avatarResult = validateAvatarMeta(payload.avatar)
+    if (!avatarResult.ok) {
+      return { success: false, message: avatarResult.message }
+    }
+    try {
+      const record = await db.users.get(email)
+      if (!record) {
+        return { success: false, message: '账号不存在或已被删除' }
+      }
+      const next: UserRecord = {
+        ...record,
+        displayName: normalizedName,
+        avatar: avatarResult.value,
+        updatedAt: Date.now(),
+      }
+      await db.users.put(next)
+      set({ profile: mapRecordToProfile(next) })
+      return { success: true }
+    } catch (error) {
+      console.error('Failed to update user profile', error)
+      return { success: false, message: '保存资料失败，请稍后重试' }
+    }
   },
 }))
+
+export const selectAuthProfile = (state: AuthState) => state.profile
+export const selectAuthEmail = (state: AuthState) => state.email
+export const selectAuthInitialized = (state: AuthState) => state.initialized

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -28,6 +28,8 @@ describe('sqlite database helpers', () => {
       email: 'user@example.com',
       salt: 'salt',
       keyHash: 'hash',
+      displayName: 'User',
+      avatar: null,
       createdAt: now,
       updatedAt: now,
     }

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -164,6 +164,14 @@ class MockSqliteDatabase {
       return results
     }
 
+    const simpleMatch = trimmed.match(/^SELECT\s+(.+?)\s+FROM\s+(\w+)$/i)
+    if (simpleMatch) {
+      const [, columnSection, table] = simpleMatch
+      const rows = [...this.ensureTable(table)]
+      const columns = columnSection.split(',').map(part => part.trim())
+      return rows.map(row => this.pickColumns(row, columns)) as T[]
+    }
+
     throw new Error(`Unhandled SQL select mock: ${query}`)
   }
 


### PR DESCRIPTION
## Summary
- extend persisted user schema with display names and avatar metadata plus migrations for Dexie and SQLite
- add profile state and update APIs in the auth store with sensitive word validation utilities
- introduce a reusable avatar uploader and update the Settings page with profile editing UI

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck *(fails: existing type errors in CommandPalette/Docs/Passwords)*

------
https://chatgpt.com/codex/tasks/task_e_68cfafad115c833184d7fd82812bf6d2