### PR TITLE
Move idle lock duration setting to settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import Passwords from './routes/Passwords'
 import Sites from './routes/Sites'
 import Docs from './routes/Docs'
 import Settings from './routes/Settings'
-import { IdleLockSelector } from './features/lock/IdleLock'
 import { useLock } from './features/lock/LockProvider'
 
 function GuestLayout({ children }: { children: ReactNode }) {
@@ -65,10 +64,7 @@ function AuthenticatedLayout() {
               </button>
             </div>
             {email && !locked && (
-              <div className="flex w-full min-w-[220px] flex-col items-end gap-2 text-xs text-text/80">
-                <div className="w-full">
-                  <IdleLockSelector />
-                </div>
+              <div className="flex w-full min-w-[220px] justify-end">
                 <button
                   type="button"
                   onClick={() => {

--- a/src/features/lock/IdleLock.tsx
+++ b/src/features/lock/IdleLock.tsx
@@ -4,9 +4,19 @@ import { useAuthStore } from '../../stores/auth'
 import { useLock } from './LockProvider'
 
 const STORAGE_KEY = 'pms-web-idle-timeout'
-const DEFAULT_TIMEOUT = 5 * 60 * 1000
+export const DEFAULT_TIMEOUT = 5 * 60 * 1000
 
-type IdleDuration = number | 'off'
+export type IdleDuration = number | 'off'
+
+type IdleTimeoutOption = { label: string; value: IdleDuration }
+
+export const IDLE_TIMEOUT_OPTIONS: IdleTimeoutOption[] = [
+  { label: '不自动锁定', value: 'off' },
+  { label: '1 分钟', value: 60_000 },
+  { label: '5 分钟', value: 5 * 60_000 },
+  { label: '10 分钟', value: 10 * 60_000 },
+  { label: '30 分钟', value: 30 * 60_000 },
+]
 
 type IdleTimeoutState = {
   duration: IdleDuration
@@ -77,11 +87,14 @@ export function IdleLockSelector() {
         onChange={event => handleChange(event.target.value)}
         className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-xs text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
       >
-        <option value="off">不自动锁定</option>
-        <option value={60_000}>1 分钟</option>
-        <option value={5 * 60_000}>5 分钟</option>
-        <option value={10 * 60_000}>10 分钟</option>
-        <option value={30 * 60_000}>30 分钟</option>
+        {IDLE_TIMEOUT_OPTIONS.map(option => (
+          <option
+            key={String(option.value)}
+            value={option.value === 'off' ? 'off' : String(option.value)}
+          >
+            {option.label}
+          </option>
+        ))}
       </select>
     </label>
   )

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react'
 import AvatarUploader from '../components/AvatarUploader'
+import { DEFAULT_TIMEOUT, IDLE_TIMEOUT_OPTIONS, useIdleTimeoutStore } from '../features/lock/IdleLock'
 import { selectAuthProfile, useAuthStore } from '../stores/auth'
 import type { UserAvatarMeta } from '../stores/database'
 import { resolveEffectiveTheme, type ThemeMode, useTheme } from '../stores/theme'
@@ -199,6 +200,8 @@ export default function Settings() {
         </form>
       </section>
 
+      <IdleTimeoutSettingsSection />
+
       <section className="space-y-5 rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-sm">
         <div className="space-y-1">
           <h2 className="text-lg font-medium text-text">主题模式</h2>
@@ -253,5 +256,50 @@ export default function Settings() {
         </fieldset>
       </section>
     </div>
+  )
+}
+
+function IdleTimeoutSettingsSection() {
+  const duration = useIdleTimeoutStore(state => state.duration)
+  const setDuration = useIdleTimeoutStore(state => state.setDuration)
+
+  const handleDurationChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.currentTarget.value
+    if (value === 'off') {
+      setDuration('off')
+      return
+    }
+    const parsed = Number(value)
+    setDuration(Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT)
+  }
+
+  return (
+    <section className="space-y-5 rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-sm">
+      <div className="space-y-1">
+        <h2 className="text-lg font-medium text-text">安全设置</h2>
+        <p className="text-sm text-muted">选择自动锁定时长，离开时也能保护数据安全。</p>
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="settings-idle-timeout" className="text-sm font-medium text-text">
+          自动锁定时长
+        </label>
+        <select
+          id="settings-idle-timeout"
+          value={duration === 'off' ? 'off' : String(duration)}
+          onChange={handleDurationChange}
+          className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
+        >
+          {IDLE_TIMEOUT_OPTIONS.map(option => (
+            <option
+              key={String(option.value)}
+              value={option.value === 'off' ? 'off' : String(option.value)}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-muted">未操作超过设定时间后应用会自动锁定，需要重新输入主密码才能继续使用。</p>
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- remove the idle lock duration selector from the authenticated header so only the manual lock action remains there
- export idle lock timeout metadata and reuse it to render the selector options
- add a dedicated security section on the settings page to edit the automatic lock duration

## Testing
- pnpm lint
- pnpm typecheck *(fails: existing errors in src/components/CommandPalette.tsx, src/routes/Docs.tsx, src/routes/Passwords.tsx)*
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cfbc3300dc8331a2cd762bc9f0ef34