### PR TITLE
feat(settings): add password change and account deletion

### DIFF
--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -200,7 +200,11 @@ export default function Settings() {
         </form>
       </section>
 
+      <ChangePasswordSection />
+
       <IdleTimeoutSettingsSection />
+
+      <DeleteAccountSection />
 
       <section className="space-y-5 rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-sm">
         <div className="space-y-1">
@@ -302,4 +306,420 @@ function IdleTimeoutSettingsSection() {
       </div>
     </section>
   )
+}
+
+function ChangePasswordSection() {
+  const email = useAuthStore(state => state.email)
+  const changePassword = useAuthStore(state => state.changePassword)
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [captchaCode, setCaptchaCode] = useState(() => generateCaptcha())
+  const [captchaInput, setCaptchaInput] = useState('')
+  const [formMessage, setFormMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const loggedIn = Boolean(email)
+  const inputsDisabled = !loggedIn || isSubmitting
+
+  const refreshCaptcha = () => {
+    setCaptchaCode(generateCaptcha())
+    setCaptchaInput('')
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!email) {
+      setFormMessage({ type: 'error', text: '请先登录后再修改密码' })
+      return
+    }
+    if (!currentPassword) {
+      setFormMessage({ type: 'error', text: '请输入旧密码' })
+      return
+    }
+    if (!newPassword) {
+      setFormMessage({ type: 'error', text: '请输入新密码' })
+      return
+    }
+    if (newPassword.length < 6) {
+      setFormMessage({ type: 'error', text: '新密码至少需要 6 位字符' })
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      setFormMessage({ type: 'error', text: '两次输入的新密码不一致' })
+      return
+    }
+    const normalizedCaptcha = captchaInput.trim().toUpperCase()
+    if (!normalizedCaptcha) {
+      setFormMessage({ type: 'error', text: '请输入验证码' })
+      return
+    }
+    if (normalizedCaptcha !== captchaCode) {
+      setFormMessage({ type: 'error', text: '验证码不正确，请重新输入' })
+      refreshCaptcha()
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      setFormMessage(null)
+      const result = await changePassword({ currentPassword, newPassword })
+      if (result.success) {
+        setFormMessage({ type: 'success', text: '密码已更新，请记住新密码。' })
+        setCurrentPassword('')
+        setNewPassword('')
+        setConfirmPassword('')
+        refreshCaptcha()
+      } else {
+        setFormMessage({ type: 'error', text: result.message ?? '修改密码失败，请稍后重试' })
+        refreshCaptcha()
+      }
+    } catch (error) {
+      console.error('Failed to submit change password form', error)
+      setFormMessage({ type: 'error', text: '修改密码失败，请稍后重试' })
+      refreshCaptcha()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="space-y-5 rounded-2xl border border-border/60 bg-surface/80 p-6 shadow-sm">
+      <div className="space-y-1">
+        <h2 className="text-lg font-medium text-text">修改密码</h2>
+        <p className="text-sm text-muted">定期更新主密码可以提升账户安全性。</p>
+      </div>
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label htmlFor="change-password-current" className="text-sm font-medium text-text">
+            旧密码
+          </label>
+          <input
+            id="change-password-current"
+            type="password"
+            autoComplete="current-password"
+            value={currentPassword}
+            onChange={event => {
+              setCurrentPassword(event.currentTarget.value)
+              setFormMessage(null)
+            }}
+            placeholder="请输入当前登录密码"
+            disabled={inputsDisabled}
+            className={clsx(
+              'w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover',
+              inputsDisabled && 'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="change-password-new" className="text-sm font-medium text-text">
+            新密码
+          </label>
+          <input
+            id="change-password-new"
+            type="password"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={event => {
+              setNewPassword(event.currentTarget.value)
+              setFormMessage(null)
+            }}
+            placeholder="不少于 6 位"
+            disabled={inputsDisabled}
+            className={clsx(
+              'w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover',
+              inputsDisabled && 'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="change-password-confirm" className="text-sm font-medium text-text">
+            确认新密码
+          </label>
+          <input
+            id="change-password-confirm"
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={event => {
+              setConfirmPassword(event.currentTarget.value)
+              setFormMessage(null)
+            }}
+            placeholder="再次输入新密码"
+            disabled={inputsDisabled}
+            className={clsx(
+              'w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover',
+              inputsDisabled && 'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="change-password-captcha" className="text-sm font-medium text-text">
+            图形验证码
+          </label>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="inline-flex min-w-[96px] justify-center rounded-xl border border-border bg-surface px-3 py-2 text-base font-semibold tracking-[0.3em] text-text shadow-inner">
+              {captchaCode}
+            </span>
+            <button
+              type="button"
+              onClick={refreshCaptcha}
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded-xl border border-border/60 px-3 py-2 text-xs font-medium text-text transition hover:border-border hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              看不清？换一个
+            </button>
+          </div>
+          <input
+            id="change-password-captcha"
+            type="text"
+            inputMode="text"
+            autoComplete="off"
+            value={captchaInput}
+            onChange={event => {
+              setCaptchaInput(event.currentTarget.value)
+              setFormMessage(null)
+            }}
+            placeholder="输入上方验证码"
+            disabled={inputsDisabled}
+            className={clsx(
+              'w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover',
+              inputsDisabled && 'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          />
+          <p className="text-xs text-muted">验证码不区分大小写。</p>
+        </div>
+
+        {formMessage ? (
+          <div
+            role="alert"
+            className={clsx(
+              'rounded-xl border px-3 py-2 text-sm shadow-sm',
+              formMessage.type === 'success'
+                ? 'border-primary/50 bg-primary/10 text-primary'
+                : 'border-red-400/70 bg-red-500/10 text-red-400',
+            )}
+          >
+            {formMessage.text}
+          </div>
+        ) : null}
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={inputsDisabled}
+            className={clsx(
+              'inline-flex items-center rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-background shadow-sm transition',
+              'hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/50',
+            )}
+          >
+            {isSubmitting ? '修改中…' : '保存新密码'}
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}
+
+function DeleteAccountSection() {
+  const email = useAuthStore(state => state.email)
+  const deleteAccount = useAuthStore(state => state.deleteAccount)
+  const [password, setPassword] = useState('')
+  const [captchaCode, setCaptchaCode] = useState(() => generateCaptcha())
+  const [captchaInput, setCaptchaInput] = useState('')
+  const [acknowledged, setAcknowledged] = useState(false)
+  const [formMessage, setFormMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const loggedIn = Boolean(email)
+  const inputsDisabled = !loggedIn || isSubmitting
+
+  const refreshCaptcha = () => {
+    setCaptchaCode(generateCaptcha())
+    setCaptchaInput('')
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!email) {
+      setFormMessage({ type: 'error', text: '请先登录后再执行注销操作' })
+      return
+    }
+    if (!acknowledged) {
+      setFormMessage({ type: 'error', text: '请先确认已了解注销后果' })
+      return
+    }
+    if (!password) {
+      setFormMessage({ type: 'error', text: '请输入密码以确认身份' })
+      return
+    }
+    const normalizedCaptcha = captchaInput.trim().toUpperCase()
+    if (!normalizedCaptcha) {
+      setFormMessage({ type: 'error', text: '请输入验证码' })
+      return
+    }
+    if (normalizedCaptcha !== captchaCode) {
+      setFormMessage({ type: 'error', text: '验证码不正确，请重新输入' })
+      refreshCaptcha()
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      setFormMessage(null)
+      const result = await deleteAccount(password)
+      if (result.success) {
+        setFormMessage({ type: 'success', text: '账号已注销，正在退出登录。' })
+        setPassword('')
+        setAcknowledged(false)
+        refreshCaptcha()
+      } else {
+        setFormMessage({ type: 'error', text: result.message ?? '注销失败，请稍后再试' })
+        refreshCaptcha()
+      }
+    } catch (error) {
+      console.error('Failed to submit delete account form', error)
+      setFormMessage({ type: 'error', text: '注销失败，请稍后再试' })
+      refreshCaptcha()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="space-y-5 rounded-2xl border border-red-400/60 bg-red-500/5 p-6 shadow-sm">
+      <div className="space-y-1">
+        <h2 className="text-lg font-medium text-text">注销账号</h2>
+        <p className="text-sm text-muted">
+          注销后账号及所有数据将立即删除且无法恢复，请谨慎操作。
+        </p>
+      </div>
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label htmlFor="delete-account-password" className="text-sm font-medium text-text">
+            登录密码
+          </label>
+          <input
+            id="delete-account-password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={event => {
+              setPassword(event.currentTarget.value)
+              setFormMessage(null)
+            }}
+            placeholder="请输入当前登录密码"
+            disabled={inputsDisabled}
+            className={clsx(
+              'w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-red-400/70 focus:bg-surface-hover',
+              inputsDisabled && 'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="delete-account-captcha" className="text-sm font-medium text-text">
+            图形验证码
+          </label>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="inline-flex min-w-[96px] justify-center rounded-xl border border-border bg-surface px-3 py-2 text-base font-semibold tracking-[0.3em] text-text shadow-inner">
+              {captchaCode}
+            </span>
+            <button
+              type="button"
+              onClick={refreshCaptcha}
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded-xl border border-border/60 px-3 py-2 text-xs font-medium text-text transition hover:border-border hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              看不清？换一个
+            </button>
+          </div>
+          <input
+            id="delete-account-captcha"
+            type="text"
+            inputMode="text"
+            autoComplete="off"
+            value={captchaInput}
+            onChange={event => {
+              setCaptchaInput(event.currentTarget.value)
+              setFormMessage(null)
+            }}
+            placeholder="输入上方验证码"
+            disabled={inputsDisabled}
+            className={clsx(
+              'w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-red-400/70 focus:bg-surface-hover',
+              inputsDisabled && 'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          />
+          <p className="text-xs text-muted">验证码不区分大小写。</p>
+        </div>
+
+        <label className="flex items-start gap-2 text-xs text-muted">
+          <input
+            type="checkbox"
+            checked={acknowledged}
+            onChange={event => {
+              setAcknowledged(event.currentTarget.checked)
+              setFormMessage(null)
+            }}
+            disabled={inputsDisabled}
+            className="mt-0.5 h-4 w-4 rounded border border-border accent-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+          />
+          <span>
+            我已了解注销后账号及所有数据将被永久删除，且无法恢复。
+          </span>
+        </label>
+
+        {formMessage ? (
+          <div
+            role="alert"
+            className={clsx(
+              'rounded-xl border px-3 py-2 text-sm shadow-sm',
+              formMessage.type === 'success'
+                ? 'border-primary/50 bg-primary/10 text-primary'
+                : 'border-red-400/70 bg-red-500/10 text-red-400',
+            )}
+          >
+            {formMessage.text}
+          </div>
+        ) : null}
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={inputsDisabled || !acknowledged}
+            className={clsx(
+              'inline-flex items-center rounded-xl bg-red-500 px-5 py-2 text-sm font-semibold text-background shadow-sm transition',
+              'hover:bg-red-500/90 disabled:cursor-not-allowed disabled:bg-red-500/50',
+            )}
+          >
+            {isSubmitting ? '正在注销…' : '立即注销'}
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}
+
+function generateCaptcha(length = 5) {
+  const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+  if (length <= 0) return ''
+  const chars: string[] = []
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const randomValues = new Uint8Array(length)
+    crypto.getRandomValues(randomValues)
+    for (let i = 0; i < randomValues.length; i += 1) {
+      const index = randomValues[i] % charset.length
+      chars.push(charset.charAt(index))
+    }
+  } else {
+    for (let i = 0; i < length; i += 1) {
+      const index = Math.floor(Math.random() * charset.length)
+      chars.push(charset.charAt(index))
+    }
+  }
+  return chars.join('')
 }

--- a/src/stores/database.ts
+++ b/src/stores/database.ts
@@ -67,6 +67,7 @@ export interface OwnedCollection<T extends { ownerEmail: string }> {
 export interface UsersTable {
   get(key: string): Promise<UserRecord | undefined>
   put(record: UserRecord): Promise<string>
+  delete(key: string): Promise<void>
 }
 
 export interface DatabaseClient {
@@ -230,6 +231,7 @@ function createDexieClient(): DatabaseClient {
     users: {
       get: key => database.users.get(key),
       put: record => database.users.put(record),
+      delete: key => database.users.delete(key),
     },
     passwords: createDexieOwnedCollection(database.passwords),
     sites: createDexieOwnedCollection(database.sites),

--- a/src/stores/sqlite.ts
+++ b/src/stores/sqlite.ts
@@ -262,6 +262,9 @@ function createUsersCollection(connection: Database): UsersTable {
       )
       return record.email
     },
+    async delete(key) {
+      await connection.execute('DELETE FROM users WHERE email = ?', [key])
+    },
   }
 }
 


### PR DESCRIPTION
## Summary
- add password change form with captcha on the settings page and rotate stored credentials after validation
- implement account deletion flow with password & captcha verification while clearing all user-owned data
- extend auth/database stores with helpers for password updates and deletions across Dexie and SQLite backends

## Testing
- pnpm typecheck *(fails: existing type errors in unrelated CommandPalette/Docs/Passwords files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc1481f708331b5f1d8ad20723a9f