### PR TITLE
feat: support tagging across vault items

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -25,6 +25,7 @@ type AppLayoutProps = {
   actions?: ReactNode
   viewMode?: 'card' | 'list'
   onViewModeChange?: (mode: 'card' | 'list') => void
+  filters?: ReactNode
 }
 
 export function AppLayout({
@@ -40,6 +41,7 @@ export function AppLayout({
   actions,
   viewMode = 'card',
   onViewModeChange,
+  filters,
 }: AppLayoutProps) {
   const viewModes: Array<{ value: 'card' | 'list'; label: string; icon: ReactNode }> = [
     { value: 'card', label: '卡片视图', icon: <LayoutGrid className="h-3.5 w-3.5" aria-hidden /> },
@@ -111,6 +113,7 @@ export function AppLayout({
             )}
           </div>
         </div>
+        {filters && <div className="flex flex-wrap gap-3">{filters}</div>}
       </header>
       <section>{children}</section>
       {commandPalette && (

--- a/src/components/TagFilter.tsx
+++ b/src/components/TagFilter.tsx
@@ -1,0 +1,48 @@
+import clsx from 'clsx'
+
+type TagFilterProps = {
+  tags: string[]
+  selected: string[]
+  onToggle: (tag: string) => void
+  onClear: () => void
+}
+
+export function TagFilter({ tags, selected, onToggle, onClear }: TagFilterProps) {
+  if (tags.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs uppercase tracking-wide text-muted">标签筛选</span>
+      {tags.map(tag => {
+        const active = selected.includes(tag)
+        return (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => onToggle(tag)}
+            aria-pressed={active}
+            className={clsx(
+              'inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              active
+                ? 'border-primary/60 bg-primary text-background shadow'
+                : 'border-border bg-surface text-muted hover:text-text',
+            )}
+          >
+            #{tag}
+          </button>
+        )
+      })}
+      {selected.length > 0 && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="inline-flex items-center rounded-full border border-border bg-surface px-3 py-1 text-xs font-semibold text-muted transition hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          清除筛选
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -48,4 +48,19 @@ describe('AppLayout', () => {
     expect(cardButton).toHaveAttribute('aria-pressed', 'false')
     expect(listButton).toHaveAttribute('aria-pressed', 'true')
   })
+
+  it('renders filters when provided', () => {
+    render(
+      <AppLayout
+        title="带筛选"
+        searchValue=""
+        onSearchChange={() => {}}
+        filters={<div data-testid="filters">filters</div>}
+      >
+        <div>内容</div>
+      </AppLayout>,
+    )
+
+    expect(screen.getByTestId('filters')).toBeInTheDocument()
+  })
 })

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,39 @@
+export function normalizeTags(tags: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of tags) {
+    if (typeof raw !== 'string') continue
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    const withoutHash = trimmed.replace(/^#+/, '')
+    const normalized = withoutHash.trim()
+    if (!normalized) continue
+    const key = normalized.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(normalized)
+  }
+  return result
+}
+
+export function parseTagsInput(input: string): string[] {
+  if (typeof input !== 'string') return []
+  const segments = input
+    .split(/[,，;；、\n]+/)
+    .map(segment => segment.trim())
+    .filter(Boolean)
+  return normalizeTags(segments)
+}
+
+export function ensureTagsArray(tags: string[] | undefined | null): string[] {
+  if (!Array.isArray(tags)) return []
+  return normalizeTags(tags)
+}
+
+export function matchesAllTags(itemTags: string[] | undefined, requiredTags: string[]): boolean {
+  if (requiredTags.length === 0) return true
+  const normalizedItemTags = normalizeTags(itemTags ?? [])
+  if (normalizedItemTags.length === 0) return false
+  const itemSet = new Set(normalizedItemTags.map(tag => tag.toLowerCase()))
+  return requiredTags.every(tag => itemSet.has(tag.toLowerCase()))
+}

--- a/src/routes/Passwords.tsx
+++ b/src/routes/Passwords.tsx
@@ -5,6 +5,7 @@ import { AppLayout } from '../components/AppLayout'
 import { DetailsDrawer } from '../components/DetailsDrawer'
 import { Empty } from '../components/Empty'
 import { Skeleton } from '../components/Skeleton'
+import { TagFilter } from '../components/TagFilter'
 import { VaultItemCard } from '../components/VaultItemCard'
 import { VaultItemList } from '../components/VaultItemList'
 import { DEFAULT_CLIPBOARD_CLEAR_DELAY, copyTextAutoClear } from '../lib/clipboard'
@@ -13,6 +14,7 @@ import { useToast } from '../components/ToastProvider'
 import { useGlobalShortcuts } from '../hooks/useGlobalShortcuts'
 import { useAuthStore } from '../stores/auth'
 import { db, type PasswordRecord } from '../stores/database'
+import { ensureTagsArray, matchesAllTags, parseTagsInput } from '../lib/tags'
 
 const CLIPBOARD_CLEAR_DELAY_SECONDS = Math.round(DEFAULT_CLIPBOARD_CLEAR_DELAY / 1_000)
 const PASSWORD_VIEW_MODE_STORAGE_KEY = 'pms:view:passwords'
@@ -22,6 +24,7 @@ type PasswordDraft = {
   username: string
   password: string
   url: string
+  tags: string
 }
 
 const EMPTY_DRAFT: PasswordDraft = {
@@ -29,6 +32,7 @@ const EMPTY_DRAFT: PasswordDraft = {
   username: '',
   password: '',
   url: '',
+  tags: '',
 }
 
 export default function Passwords() {
@@ -46,6 +50,7 @@ export default function Passwords() {
   const [draft, setDraft] = useState<PasswordDraft>(EMPTY_DRAFT)
   const [formError, setFormError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [viewMode, setViewMode] = useState<'card' | 'list'>(() => {
     if (typeof window === 'undefined') return 'card'
     const stored = window.localStorage.getItem(PASSWORD_VIEW_MODE_STORAGE_KEY)
@@ -73,7 +78,8 @@ export default function Passwords() {
       try {
         const rows = await db.passwords.where('ownerEmail').equals(currentEmail).toArray()
         rows.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-        setItems(rows)
+        const normalized = rows.map(row => ({ ...row, tags: ensureTagsArray(row.tags) }))
+        setItems(normalized)
       } finally {
         setLoading(false)
       }
@@ -82,12 +88,38 @@ export default function Passwords() {
     void load(email)
   }, [email])
 
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>()
+    items.forEach(item => {
+      ensureTagsArray(item.tags).forEach(tag => tagSet.add(tag))
+    })
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b))
+  }, [items])
+
+  useEffect(() => {
+    setSelectedTags(prev => prev.filter(tag => availableTags.includes(tag)))
+  }, [availableTags])
+
+  function toggleTag(tag: string) {
+    setSelectedTags(prev => {
+      if (prev.includes(tag)) {
+        return prev.filter(item => item !== tag)
+      }
+      return [...prev, tag]
+    })
+  }
+
+  function clearTagFilters() {
+    setSelectedTags([])
+  }
+
   const fuse = useMemo(() => {
     return new Fuse(items, {
       keys: [
         { name: 'title', weight: 0.6 },
         { name: 'username', weight: 0.3 },
         { name: 'url', weight: 0.1 },
+        { name: 'tags', weight: 0.2 },
       ],
       threshold: 0.3,
       ignoreLocation: true,
@@ -95,24 +127,46 @@ export default function Passwords() {
   }, [items])
 
   const filteredItems = useMemo(() => {
-    if (!searchTerm.trim()) {
-      return items
+    const trimmed = searchTerm.trim()
+    const base = trimmed ? fuse.search(trimmed).map(result => result.item) : items
+    if (selectedTags.length === 0) {
+      return base
     }
-    return fuse.search(searchTerm.trim()).map(result => result.item)
-  }, [fuse, items, searchTerm])
+    return base.filter(item => matchesAllTags(item.tags, selectedTags))
+  }, [fuse, items, searchTerm, selectedTags])
 
-  const commandItems = useMemo(
+  const itemCommandItems = useMemo(
     () =>
       items
         .filter(item => typeof item.id === 'number')
-        .map(item => ({
-          id: `password-${item.id}`,
-          title: item.title,
-          subtitle: [item.username, item.url].filter(Boolean).join(' · '),
-          keywords: [item.username, item.url].filter(Boolean) as string[],
-        })),
+        .map(item => {
+          const tags = ensureTagsArray(item.tags)
+          const subtitleParts = [item.username, item.url, ...tags.map(tag => `#${tag}`)].filter(Boolean)
+          const keywords = [item.username, item.url, ...tags, ...tags.map(tag => `#${tag}`)]
+            .filter(Boolean)
+            .map(entry => String(entry))
+          return {
+            id: `password-${item.id}`,
+            title: item.title,
+            subtitle: subtitleParts.join(' · '),
+            keywords,
+          }
+        }),
     [items],
   )
+
+  const tagCommandItems = useMemo(
+    () =>
+      availableTags.map(tag => ({
+        id: `password-tag-${encodeURIComponent(tag)}`,
+        title: `筛选标签：${tag}`,
+        subtitle: selectedTags.includes(tag) ? '当前已选，点击取消筛选' : '按此标签筛选列表',
+        keywords: [tag, `#${tag}`],
+      })),
+    [availableTags, selectedTags],
+  )
+
+  const commandItems = useMemo(() => [...tagCommandItems, ...itemCommandItems], [itemCommandItems, tagCommandItems])
 
   function closeDrawer() {
     setDrawerOpen(false)
@@ -133,7 +187,13 @@ export default function Passwords() {
   function handleView(item: PasswordRecord) {
     setActiveItem(item)
     setDrawerMode('view')
-    setDraft({ ...EMPTY_DRAFT, title: item.title, username: item.username, url: item.url ?? '' })
+    setDraft({
+      ...EMPTY_DRAFT,
+      title: item.title,
+      username: item.username,
+      url: item.url ?? '',
+      tags: ensureTagsArray(item.tags).join(', '),
+    })
     setDrawerOpen(true)
   }
 
@@ -145,6 +205,7 @@ export default function Passwords() {
       username: item.username,
       password: '',
       url: item.url ?? '',
+      tags: ensureTagsArray(item.tags).join(', '),
     })
     setDrawerOpen(true)
   }
@@ -210,12 +271,12 @@ export default function Passwords() {
     const confirmed = window.confirm(`确定要删除“${item.title}”吗？此操作不可恢复。`)
     if (!confirmed) return
     try {
-      await db.passwords.delete(item.id)
+        await db.passwords.delete(item.id)
       showToast({ title: '密码已删除', variant: 'success' })
       if (email) {
         const rows = await db.passwords.where('ownerEmail').equals(email).toArray()
         rows.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-        setItems(rows)
+        setItems(rows.map(row => ({ ...row, tags: ensureTagsArray(row.tags) })))
       }
       closeDrawer()
     } catch (error) {
@@ -235,6 +296,7 @@ export default function Passwords() {
     const trimmedUsername = draft.username.trim()
     const trimmedUrl = draft.url.trim()
     const passwordInput = draft.password.trim()
+    const parsedTags = parseTagsInput(draft.tags)
 
     if (!trimmedTitle) {
       setFormError('请填写名称')
@@ -275,6 +337,7 @@ export default function Passwords() {
           username: trimmedUsername,
           passwordCipher,
           url: trimmedUrl || undefined,
+          tags: parsedTags,
           createdAt: now,
           updatedAt: now,
         })
@@ -286,6 +349,7 @@ export default function Passwords() {
           username: trimmedUsername,
           passwordCipher,
           url: trimmedUrl || undefined,
+          tags: parsedTags,
           updatedAt: now,
         })
         showToast({ title: '密码已更新', variant: 'success' })
@@ -294,7 +358,7 @@ export default function Passwords() {
       if (email) {
         const rows = await db.passwords.where('ownerEmail').equals(email).toArray()
         rows.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-        setItems(rows)
+        setItems(rows.map(row => ({ ...row, tags: ensureTagsArray(row.tags) })))
       }
 
       closeDrawer()
@@ -306,6 +370,16 @@ export default function Passwords() {
   }
 
   function handleCommandSelect(commandId: string) {
+    if (commandId.startsWith('password-tag-')) {
+      const encoded = commandId.replace('password-tag-', '')
+      try {
+        const tag = decodeURIComponent(encoded)
+        toggleTag(tag)
+      } catch {
+        // ignore malformed tag ids
+      }
+      return
+    }
     const id = Number(commandId.replace('password-', ''))
     const target = items.find(item => item.id === id)
     if (target) {
@@ -324,7 +398,13 @@ export default function Passwords() {
       if (drawerOpen) {
         if (drawerMode === 'edit' && activeItem) {
           setDrawerMode('view')
-          setDraft({ ...EMPTY_DRAFT, title: activeItem.title, username: activeItem.username, url: activeItem.url ?? '' })
+          setDraft({
+            ...EMPTY_DRAFT,
+            title: activeItem.title,
+            username: activeItem.username,
+            url: activeItem.url ?? '',
+            tags: ensureTagsArray(activeItem.tags).join(', '),
+          })
         } else {
           closeDrawer()
         }
@@ -340,7 +420,7 @@ export default function Passwords() {
       description="集中管理常用账号与密码信息，可使用搜索或快捷键快速定位。"
       searchValue={searchTerm}
       onSearchChange={setSearchTerm}
-      searchPlaceholder="搜索名称、用户名或网址"
+      searchPlaceholder="搜索名称、用户名、网址或标签"
       createLabel="新增密码"
       onCreate={handleCreate}
       commandPalette={{
@@ -353,6 +433,9 @@ export default function Passwords() {
       }}
       viewMode={viewMode}
       onViewModeChange={setViewMode}
+      filters={
+        <TagFilter tags={availableTags} selected={selectedTags} onToggle={toggleTag} onClear={clearTagFilters} />
+      }
     >
       {loading ? (
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -381,6 +464,7 @@ export default function Passwords() {
                 title={item.title}
                 description={item.username ? `用户名：${item.username}` : '未填写用户名'}
                 badges={item.url ? [{ label: item.url, tone: 'info' as const }] : undefined}
+                tags={ensureTagsArray(item.tags).map(tag => ({ id: tag, name: tag }))}
                 updatedAt={item.updatedAt}
                 onOpen={() => handleView(item)}
                 actions={actions}
@@ -395,6 +479,7 @@ export default function Passwords() {
             title: item.title,
             description: item.username ? `用户名：${item.username}` : '未填写用户名',
             metadata: item.url ? [`网址：${item.url}`] : undefined,
+            tags: ensureTagsArray(item.tags).map(tag => ({ id: tag, name: tag })),
             updatedAt: item.updatedAt,
             onOpen: () => handleView(item),
             actions: buildItemActions(item),
@@ -472,6 +557,20 @@ export default function Passwords() {
               <p className="mt-1 break-all text-base text-primary">{activeItem.url || '未填写'}</p>
             </div>
             <div>
+              <p className="text-xs text-muted">标签</p>
+              {ensureTagsArray(activeItem.tags).length > 0 ? (
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {ensureTagsArray(activeItem.tags).map(tag => (
+                    <span key={tag} className="inline-flex items-center rounded-full bg-surface-hover px-2.5 py-0.5 text-xs text-muted">
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-1 text-base text-text">未设置</p>
+              )}
+            </div>
+            <div>
               <p className="text-xs text-muted">最近更新</p>
               <p className="mt-1 text-base text-text">
                 {activeItem.updatedAt ? new Date(activeItem.updatedAt).toLocaleString() : '未知'}
@@ -520,6 +619,16 @@ export default function Passwords() {
                 className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
                 placeholder="https://example.com"
               />
+            </label>
+            <label className="block space-y-2">
+              <span className="text-xs uppercase tracking-wide text-muted">标签</span>
+              <input
+                value={draft.tags}
+                onChange={event => setDraft(prev => ({ ...prev, tags: event.target.value }))}
+                className="w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
+                placeholder="例如：工作, 邮箱"
+              />
+              <p className="text-xs text-muted">多个标签请使用逗号分隔，支持在搜索和命令面板中快速定位。</p>
             </label>
             {formError && <p className="text-sm text-rose-300">{formError}</p>}
             <div className="flex justify-end gap-3">

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -108,6 +108,18 @@ class MockSqliteDatabase {
       return
     }
 
+    const updateTagsMatch = trimmed.match(/^UPDATE\s+(passwords|sites|docs)\s+SET\s+tags\s*=\s*'\[\]'\s+WHERE\s+tags\s+IS\s+NULL/i)
+    if (updateTagsMatch) {
+      const table = updateTagsMatch[1]
+      const rows = this.ensureTable(table)
+      for (const row of rows) {
+        if (row.tags === null || row.tags === undefined) {
+          row.tags = '[]'
+        }
+      }
+      return
+    }
+
     throw new Error(`Unhandled SQL execute mock: ${query}`)
   }
 


### PR DESCRIPTION
## Summary
- add optional tag arrays to password, site, and document records with Dexie/SQLite migrations to persist new indices
- introduce shared tag parsing utilities and a TagFilter component, wiring tag capture, display, and filtering into the Passwords, Sites, and Docs routes
- extend AppLayout to host filter controls and adjust tests/mocks for the new tag behaviors

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68cfe9b28ac88331b469b6550153bfea