### PR TITLE
Ensure onboarding layout tolerates missing spId

### DIFF
--- a/src/routes/onboarding/OnboardingLayout.tsx
+++ b/src/routes/onboarding/OnboardingLayout.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+import { useMemo } from 'react'
+import { useAuthStore } from '../../stores/auth'
+
+function fallbackDisplayName(email: string | null | undefined, displayName: string | null | undefined) {
+  const normalizedName = typeof displayName === 'string' ? displayName.replace(/\s+/g, ' ').trim() : ''
+  if (normalizedName) {
+    return normalizedName
+  }
+  const normalizedEmail = typeof email === 'string' ? email.trim() : ''
+  if (!normalizedEmail) {
+    return '用户'
+  }
+  const prefix = normalizedEmail.split('@')[0]?.trim()
+  return prefix || normalizedEmail || '用户'
+}
+
+function formatSupportId(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const normalized = value.trim()
+    return normalized ? normalized : null
+  }
+  if (typeof value === 'number') {
+    const normalized = String(value)
+    return normalized ? normalized : null
+  }
+  return null
+}
+
+type OnboardingLayoutProps = {
+  title: string
+  description?: string
+  children: ReactNode
+}
+
+export default function OnboardingLayout({ title, description, children }: OnboardingLayoutProps) {
+  const profile = useAuthStore(state => state.profile)
+  const email = useAuthStore(state => state.email)
+
+  const { displayName, accountEmail, supportId } = useMemo(() => {
+    const mergedEmail = email ?? profile?.email ?? null
+    const resolvedDisplayName = fallbackDisplayName(mergedEmail, profile?.displayName ?? null)
+    const rawSupportId = (profile as (typeof profile & { spId?: unknown }) | null)?.spId
+    const resolvedSupportId = formatSupportId(rawSupportId)
+    return {
+      displayName: resolvedDisplayName,
+      accountEmail: mergedEmail ?? '未登录',
+      supportId: resolvedSupportId ?? '未分配',
+    }
+  }, [email, profile])
+
+  return (
+    <div className="min-h-screen bg-background text-text transition-colors">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center gap-12 px-6 py-16">
+        <header className="space-y-4 text-center">
+          <div className="space-y-1 text-sm text-muted">
+            <p className="text-xs uppercase tracking-[0.3em] text-muted">当前账户</p>
+            <p className="text-base font-semibold text-text" data-testid="onboarding-display-name">
+              {displayName}
+            </p>
+            <p data-testid="onboarding-email">{accountEmail}</p>
+            <p className="text-xs text-muted" data-testid="onboarding-support-id">
+              ID：{supportId}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold text-text">{title}</h1>
+            {description && <p className="text-sm text-muted">{description}</p>}
+          </div>
+        </header>
+        <main className="flex-1">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/onboarding/__tests__/OnboardingLayout.test.tsx
+++ b/src/routes/onboarding/__tests__/OnboardingLayout.test.tsx
@@ -1,0 +1,50 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import OnboardingLayout from '../OnboardingLayout'
+import { useAuthStore } from '../../../stores/auth'
+
+describe('OnboardingLayout', () => {
+  afterEach(() => {
+    cleanup()
+    act(() => {
+      useAuthStore.setState({
+        email: null,
+        profile: null,
+        mustChangePassword: false,
+        initialized: false,
+      })
+    })
+  })
+
+  it('renders fallback support id when spId is missing', () => {
+    const { getByTestId } = render(
+      <OnboardingLayout title="欢迎" description="引导设置">
+        <p>内容</p>
+      </OnboardingLayout>
+    )
+
+    expect(getByTestId('onboarding-support-id')).toHaveTextContent('ID：未分配')
+  })
+
+  it('renders provided spId when available on profile', () => {
+    act(() => {
+      useAuthStore.setState({
+        email: 'alice@example.com',
+        profile: {
+          email: 'alice@example.com',
+          displayName: 'Alice',
+          avatar: null,
+          spId: 'SP-12345',
+        } as unknown as ReturnType<typeof useAuthStore.getState>['profile'],
+      })
+    })
+
+    const { getByTestId } = render(
+      <OnboardingLayout title="欢迎" description="引导设置">
+        <p>内容</p>
+      </OnboardingLayout>
+    )
+
+    expect(getByTestId('onboarding-support-id')).toHaveTextContent('ID：SP-12345')
+  })
+})


### PR DESCRIPTION
## Summary
- add an onboarding layout wrapper that safely derives the account name/email and falls back when spId is absent
- cover the new layout with unit tests to assert graceful rendering with and without a provided spId

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cff278ddd083319538a5a71a73de57