### PR TITLE
Fix onboarding layout auth setter

### DIFF
--- a/src/routes/OnboardingLayout.tsx
+++ b/src/routes/OnboardingLayout.tsx
@@ -1,0 +1,42 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import { Outlet } from 'react-router-dom'
+
+export type AuthMode = 'login' | 'register'
+
+type OnboardingContextValue = {
+  authMode: AuthMode
+  setAuthMode: (mode: AuthMode) => void
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | undefined>(undefined)
+
+export function useOnboardingContext(): OnboardingContextValue {
+  const context = useContext(OnboardingContext)
+  if (!context) {
+    throw new Error('useOnboardingContext must be used within OnboardingLayout')
+  }
+  return context
+}
+
+export default function OnboardingLayout() {
+  const [authMode, setAuthMode] = useState<AuthMode>('login')
+
+  const handleAuthModeChange = useCallback((mode: AuthMode) => {
+    setAuthMode(mode)
+  }, [])
+
+  const contextValue = useMemo(
+    () => ({ authMode, setAuthMode: handleAuthModeChange }),
+    [authMode, handleAuthModeChange],
+  )
+
+  return (
+    <OnboardingContext.Provider value={contextValue}>
+      <div className="min-h-screen bg-background text-text transition-colors">
+        <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-6 py-12">
+          <Outlet context={contextValue} />
+        </div>
+      </div>
+    </OnboardingContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- add an onboarding layout component that stores the auth mode with `useState`
- expose a memoised `setAuthMode` callback so the layout and children no longer call an undefined `authSet`

## Testing
- pnpm test
- pnpm dev (manual smoke check)


------
https://chatgpt.com/codex/tasks/task_e_68cff277dad0833195b85b0bb98683c8