### PR TITLE
Trigger initial load for passwords and sites

### DIFF
--- a/src/routes/Passwords.tsx
+++ b/src/routes/Passwords.tsx
@@ -107,6 +107,8 @@ export default function Passwords() {
       }
     }
 
+    void load(email)
+
     const handleImported = () => {
       void reloadItems(email)
     }

--- a/src/routes/Sites.tsx
+++ b/src/routes/Sites.tsx
@@ -99,6 +99,8 @@ export default function Sites() {
       }
     }
 
+    void load(email)
+
     const handleImported = () => {
       void reloadItems(email)
     }


### PR DESCRIPTION
## Summary
- trigger the password list query immediately when an email is available
- do the same for the sites list so the initial page shows stored entries

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cffa5c702083319d9d633166733892