### PR TITLE
Fix Dexie user migration typings

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Fuse from 'fuse.js'
+import type { IFuseOptions } from 'fuse.js'
 import clsx from 'clsx'
 
 export type CommandItem = {
@@ -17,7 +18,7 @@ type CommandPaletteProps = {
   placeholder?: string
 }
 
-const fuseOptions: Fuse.IFuseOptions<CommandItem> = {
+const fuseOptions: IFuseOptions<CommandItem> = {
   includeScore: true,
   threshold: 0.3,
   keys: [

--- a/src/routes/Passwords.tsx
+++ b/src/routes/Passwords.tsx
@@ -6,7 +6,7 @@ import { DetailsDrawer } from '../components/DetailsDrawer'
 import { Empty } from '../components/Empty'
 import { Skeleton } from '../components/Skeleton'
 import { TagFilter } from '../components/TagFilter'
-import { VaultItemCard } from '../components/VaultItemCard'
+import { VaultItemCard, type VaultItemAction } from '../components/VaultItemCard'
 import { VaultItemList } from '../components/VaultItemList'
 import { DEFAULT_CLIPBOARD_CLEAR_DELAY, copyTextAutoClear } from '../lib/clipboard'
 import { BACKUP_IMPORTED_EVENT } from '../lib/backup'
@@ -265,25 +265,31 @@ export default function Passwords() {
     }
   }
 
-  function buildItemActions(item: PasswordRecord) {
-    const actions = [
+  function buildItemActions(item: PasswordRecord): VaultItemAction[] {
+    const actions: VaultItemAction[] = [
       {
         icon: <Copy className="h-3.5 w-3.5" aria-hidden />,
         label: '复制密码',
-        onClick: () => handleCopyPassword(item),
+        onClick: () => {
+          void handleCopyPassword(item)
+        },
       },
     ]
     if (item.url) {
       actions.push({
         icon: <ExternalLink className="h-3.5 w-3.5" aria-hidden />,
         label: '打开链接',
-        onClick: () => handleOpenUrl(item),
+        onClick: () => {
+          handleOpenUrl(item)
+        },
       })
     }
     actions.push({
       icon: <Pencil className="h-3.5 w-3.5" aria-hidden />,
       label: '编辑',
-      onClick: () => handleEdit(item),
+      onClick: () => {
+        handleEdit(item)
+      },
     })
     return actions
   }

--- a/src/stores/database.ts
+++ b/src/stores/database.ts
@@ -20,6 +20,7 @@ export interface UserRecord {
   displayName: string
   avatar: UserAvatarMeta | null
   mnemonic: string
+  mustChangePassword?: boolean
   createdAt: number
   updatedAt: number
 }
@@ -192,6 +193,9 @@ class AppDatabase extends Dexie {
           displayName?: string
           avatar?: UserRecord['avatar']
           mnemonic?: string
+          createdAt?: number
+          updatedAt?: number
+          mustChangePassword?: boolean
         }
         const usersTable = tx.table('users') as Table<LegacyUserRecord, string>
         const users = await usersTable.toArray()
@@ -220,7 +224,9 @@ class AppDatabase extends Dexie {
               displayName,
               avatar: legacy.avatar ?? null,
               mnemonic: typeof legacy.mnemonic === 'string' ? legacy.mnemonic : '',
-              updatedAt: legacy.updatedAt ?? Date.now(),
+              createdAt,
+              updatedAt,
+              mustChangePassword,
             }
             await usersTable.put(next)
           }),
@@ -250,7 +256,7 @@ class AppDatabase extends Dexie {
               mnemonic,
               updatedAt: legacy.updatedAt ?? Date.now(),
             }
-            await usersTable.put(next as unknown as LegacyUserRecordV4)
+            await usersTable.put(next as LegacyUserRecord)
           }),
         )
       })


### PR DESCRIPTION
## Summary
- allow `UserRecord` to carry the optional `mustChangePassword` flag used elsewhere
- extend the Dexie v4 user migration to read legacy timestamps/password flags and persist them on the new record
- update the v5 migration to use the existing `LegacyUserRecord` alias when writing back
- fix Fuse options typing and align password action callbacks with the `VaultItemAction` signature so `pnpm typecheck` succeeds

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0185788948331acc99134b7db3cc2