### PR TITLE
Update Tauri bundle and security settings

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "devUrl": "http://localhost:5173"
   },
   "bundle": {
+    "active": true,
     "icon": [
       "icons/icon.ico",
       "icons/icon.icns"
@@ -17,6 +18,7 @@
   },
   "app": {
     "security": {
+      "csp": null,
       "capabilities": ["default"]
     },
     "windows": [


### PR DESCRIPTION
## Summary
- enable bundling by activating the Tauri bundle configuration
- add a null CSP entry while keeping the default capability

## Testing
- pnpm tauri info

------
https://chatgpt.com/codex/tasks/task_e_68d122be6ef083318415a371861c7536