### PR TITLE
Add runtime panic overlay

### DIFF
--- a/src/lib/error-overlay.ts
+++ b/src/lib/error-overlay.ts
@@ -1,0 +1,75 @@
+const OVERLAY_ID = 'panic-overlay'
+
+declare global {
+  interface Window {
+    __panicOverlayInstalled?: boolean
+  }
+}
+
+function ensureOverlay(): HTMLPreElement {
+  let overlay = document.getElementById(OVERLAY_ID) as HTMLPreElement | null
+  if (!overlay) {
+    overlay = document.createElement('pre')
+    overlay.id = OVERLAY_ID
+    overlay.setAttribute('role', 'alert')
+    overlay.setAttribute('aria-live', 'assertive')
+    overlay.style.position = 'fixed'
+    overlay.style.inset = '0'
+    overlay.style.margin = '0'
+    overlay.style.padding = '1.5rem'
+    overlay.style.fontFamily = "Menlo, Monaco, 'Courier New', monospace"
+    overlay.style.fontSize = '14px'
+    overlay.style.lineHeight = '1.5'
+    overlay.style.backgroundColor = 'rgba(15, 15, 15, 0.95)'
+    overlay.style.color = '#ff6b6b'
+    overlay.style.overflow = 'auto'
+    overlay.style.zIndex = '2147483647'
+    overlay.style.whiteSpace = 'pre-wrap'
+    overlay.style.pointerEvents = 'none'
+    overlay.style.display = 'none'
+
+    const root = document.body ?? document.documentElement
+    root.appendChild(overlay)
+  }
+  return overlay
+}
+
+const overlay = typeof document !== 'undefined' ? ensureOverlay() : null
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    if (error.stack) {
+      return error.stack
+    }
+    return `${error.name}: ${error.message}`
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  try {
+    return JSON.stringify(error, undefined, 2)
+  } catch {
+    return String(error)
+  }
+}
+
+function showOverlay(error: unknown) {
+  if (!overlay) return
+  overlay.textContent = `Unhandled Runtime Error\n\n${formatError(error)}`
+  overlay.style.display = 'block'
+  console.error(error)
+}
+
+function handleWindowError(event: ErrorEvent) {
+  showOverlay(event.error ?? event.message ?? event)
+}
+
+function handleUnhandledRejection(event: PromiseRejectionEvent) {
+  showOverlay(event.reason ?? event)
+}
+
+if (typeof window !== 'undefined' && !window.__panicOverlayInstalled) {
+  window.addEventListener('error', handleWindowError)
+  window.addEventListener('unhandledrejection', handleUnhandledRejection)
+  window.__panicOverlayInstalled = true
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import './lib/error-overlay'
 import { isTauriRuntime } from './env'
 import { swCleanup } from './lib/sw-clean'
 import React from 'react'


### PR DESCRIPTION
## Summary
- add a panic overlay module that mounts a `<pre id="panic-overlay">` element and shows unhandled errors
- import the overlay module in the application entry point so it loads before other side-effect imports

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d122bd54248331b52c640e3e37e4b5