### PR TITLE
Set Vite non-Tauri build target to modules

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     }),
   ],
   build: {
-    target: isTauri ? ['es2021'] : 'esnext',
+    target: isTauri ? ['es2021'] : 'modules',
     sourcemap: false,
   },
 })


### PR DESCRIPTION
## Summary
- change the Vite build target for non-Tauri builds from `esnext` to `modules`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d125a57e248331b2b2beebdd528fe7