### PR TITLE
Install panic overlay initialization

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import './lib/error-overlay'
+import { installPanicOverlay } from './lib/error-overlay'
 import { isTauriRuntime } from './env'
 import { swCleanup } from './lib/sw-clean'
 import React from 'react'
@@ -11,6 +11,8 @@ import IdleLock from './features/lock/IdleLock'
 import { LockProvider } from './features/lock/LockProvider'
 import { LockScreen } from './features/lock/LockScreen'
 import { initializeTheme, useTheme } from './stores/theme'
+
+installPanicOverlay()
 
 if (isTauriRuntime) {
   void swCleanup()


### PR DESCRIPTION
## Summary
- import the panic overlay installer and initialize it at application startup
- keep the service worker cleanup guarded behind the Tauri runtime check

## Testing
- eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68d125a702e4833186f0d82836d2697a