### PR TITLE
Store SQLite data in dedicated app data folder

### DIFF
--- a/src/stores/sqlite.ts
+++ b/src/stores/sqlite.ts
@@ -146,8 +146,10 @@ function normalizeParams(values: unknown[]): unknown[] {
 
 async function resolveDatabasePath() {
   const baseDir = await appDataDir()
-  await mkdir(baseDir, { recursive: true })
-  return join(baseDir, 'app.sqlite')
+  const dataDir = await join(baseDir, 'data')
+  await mkdir(dataDir, { recursive: true })
+  const dbPath = await join(dataDir, 'pms.db')
+  return dbPath
 }
 
 const MIGRATIONS: Migration[] = [

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -18,10 +18,12 @@ beforeEach(() => {
 describe('sqlite database helpers', () => {
   it('opens the database at the app data path and stores users', async () => {
     const sql = await resetEnvironment()
+    const fs = await import('@tauri-apps/plugin-fs')
     const { createSqliteDatabase } = await import('../src/stores/sqlite')
     const db = await createSqliteDatabase()
 
-    expect(sql.Database.load).toHaveBeenCalledWith('sqlite:C:/mock/AppData/pms-web/app.sqlite')
+    expect(fs.mkdir).toHaveBeenCalledWith('C:/mock/AppData/pms-web/data', { recursive: true })
+    expect(sql.Database.load).toHaveBeenCalledWith('sqlite:C:/mock/AppData/pms-web/data/pms.db')
 
     const now = Date.now()
     const user: UserRecord = {
@@ -106,6 +108,7 @@ describe('database module selection', () => {
     const sql = await resetEnvironment()
     ;(window as Record<string, unknown>).__TAURI_INTERNALS__ = {}
     const { db } = await import('../src/stores/database')
+    await db.open()
     expect(sql.Database.load).toHaveBeenCalled()
 
     const now = Date.now()


### PR DESCRIPTION
## Summary
- ensure the SQLite database is stored under an app-scoped data subdirectory
- update the database tests to assert the new location and directory creation behaviour
- wait for the lazy database client to finish opening before asserting plugin usage in tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d136cc14f48331854b03e4a6ab40e0