### PR TITLE
Configure FS and SQL capabilities for AppData access

### DIFF
--- a/src-tauri/capabilities/fs-appdata.json
+++ b/src-tauri/capabilities/fs-appdata.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "fs-appdata",
+  "description": "Allows the FS plugin to manage files within the application's AppData directory.",
+  "windows": ["main"],
+  "permissions": [
+    {
+      "identifier": "fs:scope",
+      "scope": {
+        "allow": [
+          "$APPDATA/**",
+          "$RESOURCE/**"
+        ]
+      }
+    },
+    "fs:allow-appdata-read-recursive",
+    "fs:allow-appdata-write-recursive",
+    "fs:allow-appdata-meta-recursive",
+    "fs:allow-resource-read-recursive",
+    "fs:allow-resource-meta-recursive"
+  ]
+}

--- a/src-tauri/capabilities/sqlite.json
+++ b/src-tauri/capabilities/sqlite.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "sqlite",
+  "description": "Allows the SQL plugin to interact with SQLite databases stored under AppData.",
+  "windows": ["main"],
+  "permissions": [
+    {
+      "identifier": "sql:allow-load",
+      "scope": {
+        "allow": [
+          "sqlite:$APPDATA/**.db",
+          "sqlite:$APPDATA/**/data/*.db"
+        ]
+      }
+    },
+    {
+      "identifier": "sql:allow-select",
+      "scope": {
+        "allow": [
+          "sqlite:$APPDATA/**.db",
+          "sqlite:$APPDATA/**/data/*.db"
+        ]
+      }
+    },
+    {
+      "identifier": "sql:allow-close",
+      "scope": {
+        "allow": [
+          "sqlite:$APPDATA/**.db",
+          "sqlite:$APPDATA/**/data/*.db"
+        ]
+      }
+    },
+    {
+      "identifier": "sql:allow-execute",
+      "scope": {
+        "allow": [
+          "sqlite:$APPDATA/**.db",
+          "sqlite:$APPDATA/**/data/*.db"
+        ]
+      }
+    }
+  ]
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,11 @@
   "app": {
     "security": {
       "csp": null,
-      "capabilities": ["default"]
+      "capabilities": [
+        "default",
+        "fs-appdata",
+        "sqlite"
+      ]
     },
     "windows": [
       {


### PR DESCRIPTION
## Summary
- add an fs-appdata capability so the FS plugin can manage AppData files within a tightly scoped directory list
- add a sqlite capability that allows SQL plugin commands against AppData-hosted SQLite databases only
- opt the application into the new fs-appdata and sqlite capabilities in the Tauri config

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d136cba0f88331a7d8ee76d017360b