### PR TITLE
Narrow import.meta env usage in Settings runtime detection

### DIFF
--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -44,7 +44,9 @@ function detectTauriRuntime() {
       return true
     }
   }
-  const env = import.meta.env as unknown as { TAURI_PLATFORM?: string | undefined }
+  const env = (
+    import.meta as ImportMeta & { env?: { TAURI_PLATFORM?: string | undefined } }
+  ).env
   return typeof env?.TAURI_PLATFORM === 'string' && env.TAURI_PLATFORM.length > 0
 }
 


### PR DESCRIPTION
## Summary
- cast `import.meta` to include optional `env.TAURI_PLATFORM` before reading it in the Settings runtime detection logic

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b319c6748331ac185b81c0110d77