### PR TITLE
Fix inspiration panel textarea sizing

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -13,7 +13,6 @@ import {
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useId,
   useMemo,
   useRef,
@@ -531,7 +530,7 @@ function InspirationEditor({
             value={draft.content}
             onChange={onContentChange}
             placeholder="使用 Markdown 语法编写内容，支持标题、列表、引用等格式。"
-            className="min-h-[200px] w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm leading-relaxed text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
+            className="h-64 w-full resize-none overflow-y-auto rounded-2xl border border-border bg-surface px-4 py-3 text-sm leading-relaxed text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             disabled={saving || deleting || loadingNote}
           />
           <div
@@ -610,13 +609,6 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
   const [error, setError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const tagInputRef = useRef<HTMLInputElement | null>(null)
-
-  useLayoutEffect(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-    textarea.style.height = 'auto'
-    textarea.style.height = `${textarea.scrollHeight}px`
-  }, [draft.content, draft.id, loadingNote])
 
   const activeMeta = useMemo(() => {
     if (!selectedId) return null


### PR DESCRIPTION
## Summary
- remove the layout effect that dynamically resized the inspiration note textarea
- give the textarea a fixed height with scrolling so long markdown stays within bounds

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3df61eb948331b6ac4caad0d68277