### PR TITLE
Ensure GitHub metadata persists during migrations

### DIFF
--- a/src/stores/database.ts
+++ b/src/stores/database.ts
@@ -206,6 +206,7 @@ class AppDatabase extends Dexie {
           createdAt?: number
           updatedAt?: number
           mustChangePassword?: boolean
+          github?: UserRecord['github']
         }
         const usersTable = tx.table('users') as Table<LegacyUserRecord, string>
         const users = await usersTable.toArray()
@@ -237,6 +238,7 @@ class AppDatabase extends Dexie {
               mnemonic: typeof legacy.mnemonic === 'string' ? legacy.mnemonic : '',
               createdAt,
               updatedAt,
+              github: legacy.github ?? null,
             }
             await usersTable.put(next)
           }),


### PR DESCRIPTION
## Summary
- surface legacy GitHub data during the Dexie v4 user migration and default it to null when missing
- persist GitHub connection metadata in the SQLite implementation, including serialization helpers and a schema migration

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3fde1dbc483318660e1de6a97360e