### PR TITLE
Add GitHub backup configuration support

### DIFF
--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -174,6 +174,10 @@ type BackupGithubConnection = {
   connectedAt: number
   updatedAt: number
   lastValidationAt?: number | null
+  repositoryOwner?: string | null
+  repositoryName?: string | null
+  repositoryBranch?: string | null
+  targetDirectory?: string | null
 }
 
 type BackupPayloadV1 = {
@@ -316,6 +320,11 @@ function sanitizeGithubConnection(
     lastValidationAt = normalizeTimestamp(lastValidationRaw, updatedAt)
   }
 
+  const repositoryOwner = sanitizeOptionalString((value as { repositoryOwner?: unknown }).repositoryOwner)
+  const repositoryName = sanitizeOptionalString((value as { repositoryName?: unknown }).repositoryName)
+  const repositoryBranch = sanitizeOptionalString((value as { repositoryBranch?: unknown }).repositoryBranch)
+  const targetDirectory = sanitizeOptionalString((value as { targetDirectory?: unknown }).targetDirectory)
+
   const result: BackupGithubConnection = {
     username,
     token,
@@ -324,6 +333,18 @@ function sanitizeGithubConnection(
   }
   if (lastValidationAt !== undefined) {
     result.lastValidationAt = lastValidationAt
+  }
+  if (repositoryOwner !== undefined) {
+    result.repositoryOwner = repositoryOwner ?? null
+  }
+  if (repositoryName !== undefined) {
+    result.repositoryName = repositoryName ?? null
+  }
+  if (repositoryBranch !== undefined) {
+    result.repositoryBranch = repositoryBranch ?? null
+  }
+  if (targetDirectory !== undefined) {
+    result.targetDirectory = targetDirectory ?? null
   }
   return result
 }
@@ -459,12 +480,20 @@ export async function exportUserData(
           userRecord.github.lastValidationAt ?? userRecord.github.updatedAt ?? updatedAt,
           updatedAt,
         )
+        const repositoryOwner = sanitizeOptionalString(userRecord.github.repositoryOwner)
+        const repositoryName = sanitizeOptionalString(userRecord.github.repositoryName)
+        const repositoryBranch = sanitizeOptionalString(userRecord.github.repositoryBranch)
+        const targetDirectory = sanitizeOptionalString(userRecord.github.targetDirectory)
         githubConnection = {
           username,
           token,
           connectedAt,
           updatedAt,
           lastValidationAt,
+          repositoryOwner: repositoryOwner ?? null,
+          repositoryName: repositoryName ?? null,
+          repositoryBranch: repositoryBranch ?? null,
+          targetDirectory: targetDirectory ?? null,
         }
       } catch (error) {
         console.error('Failed to decrypt GitHub token for backup export', error)
@@ -891,12 +920,20 @@ export async function importUserData(
                 parsed.github.lastValidationAt === null
                   ? updatedAt
                   : normalizeTimestamp(parsed.github.lastValidationAt, updatedAt)
+              const repositoryOwner = sanitizeOptionalString(parsed.github.repositoryOwner) ?? null
+              const repositoryName = sanitizeOptionalString(parsed.github.repositoryName) ?? null
+              const repositoryBranch = sanitizeOptionalString(parsed.github.repositoryBranch) ?? null
+              const targetDirectory = sanitizeOptionalString(parsed.github.targetDirectory) ?? null
               const githubRecord: UserGithubConnection = {
                 username: parsed.github.username,
                 tokenCipher: encryptedToken,
                 connectedAt,
                 updatedAt,
                 lastValidationAt: lastValidationSource,
+                repositoryOwner,
+                repositoryName,
+                repositoryBranch,
+                targetDirectory,
               }
               nextRecord.github = githubRecord
             } catch (error) {

--- a/src/lib/github-backup.ts
+++ b/src/lib/github-backup.ts
@@ -1,0 +1,257 @@
+const GITHUB_API_BASE_URL = 'https://api.github.com'
+const GITHUB_BACKUP_ERROR_PREFIX = 'GitHub 备份失败：'
+
+export type GithubBackupConfig = {
+  token: string
+  owner: string
+  repo: string
+  branch: string
+  path: string
+  content: string
+}
+
+export type GithubBackupOptions = {
+  commitMessage?: string
+  fetchImpl?: typeof fetch
+  maxRetries?: number
+}
+
+export type GithubBackupResult = {
+  contentPath: string
+  contentSha: string | null
+  commitSha: string | null
+  htmlUrl?: string | null
+  commitUrl?: string | null
+}
+
+class GithubBackupError extends Error {
+  readonly status?: number
+  readonly retryable: boolean
+
+  constructor(message: string, options: { status?: number; retryable?: boolean } = {}) {
+    const trimmed = message.trim()
+    const finalMessage = trimmed.startsWith(GITHUB_BACKUP_ERROR_PREFIX)
+      ? trimmed
+      : `${GITHUB_BACKUP_ERROR_PREFIX}${trimmed || '未知错误。'}`
+    super(finalMessage)
+    this.name = 'GithubBackupError'
+    this.status = options.status
+    this.retryable = options.retryable ?? false
+  }
+}
+
+function toGithubBackupError(error: unknown, fallbackMessage: string): GithubBackupError {
+  if (error instanceof GithubBackupError) {
+    return error
+  }
+  if (error instanceof Error && typeof error.message === 'string' && error.message.trim()) {
+    return new GithubBackupError(error.message)
+  }
+  return new GithubBackupError(fallbackMessage)
+}
+
+function ensureNonEmpty(value: string, label: string): string {
+  const normalized = value.trim()
+  if (!normalized) {
+    throw new GithubBackupError(`${label}不能为空。`)
+  }
+  return normalized
+}
+
+function normalizePath(value: string): string {
+  const normalized = value
+    .split('/')
+    .map(segment => segment.trim())
+    .filter(Boolean)
+    .join('/')
+  if (!normalized) {
+    throw new GithubBackupError('备份文件路径不能为空。')
+  }
+  return normalized
+}
+
+function encodeBase64(content: string): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(content, 'utf-8').toString('base64')
+  }
+  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+    const encoder = new TextEncoder()
+    const bytes = encoder.encode(content)
+    let binary = ''
+    const chunkSize = 0x8000
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      const slice = bytes.subarray(i, i + chunkSize)
+      binary += String.fromCharCode(...slice)
+    }
+    return window.btoa(binary)
+  }
+  // Fallback for environments without Buffer or btoa
+  const encoder = new TextEncoder()
+  const bytes = encoder.encode(content)
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const slice = bytes.subarray(i, i + chunkSize)
+    binary += String.fromCharCode(...slice)
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary)
+  }
+  throw new GithubBackupError('当前环境不支持 Base64 编码。')
+}
+
+async function readErrorMessage(response: Response): Promise<string | null> {
+  const contentType = response.headers.get('Content-Type') ?? ''
+  if (!contentType.includes('application/json')) {
+    return null
+  }
+  try {
+    const payload = (await response.json()) as { message?: unknown }
+    const message = typeof payload.message === 'string' ? payload.message.trim() : ''
+    return message || null
+  } catch (error) {
+    console.warn('Failed to parse GitHub error payload', error)
+    return null
+  }
+}
+
+async function requestExistingSha(
+  url: string,
+  branch: string,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+): Promise<string | null> {
+  const response = await fetchImpl(`${url}?ref=${encodeURIComponent(branch)}`, {
+    method: 'GET',
+    headers,
+  })
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    const message = await readErrorMessage(response)
+    const retryable = response.status >= 500 && response.status < 600
+    throw new GithubBackupError(message ?? `查询 GitHub 文件失败：${response.status}`, {
+      status: response.status,
+      retryable,
+    })
+  }
+  try {
+    const payload = (await response.json()) as { sha?: unknown }
+    const sha = typeof payload.sha === 'string' ? payload.sha.trim() : ''
+    return sha || null
+  } catch (error) {
+    console.warn('Failed to parse GitHub content payload', error)
+    return null
+  }
+}
+
+async function uploadContent(
+  url: string,
+  body: Record<string, unknown>,
+  fetchImpl: typeof fetch,
+  headers: Record<string, string>,
+): Promise<GithubBackupResult> {
+  const response = await fetchImpl(url, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    const message = await readErrorMessage(response)
+    const retryable = response.status >= 500 && response.status < 600
+    throw new GithubBackupError(message ?? `上传 GitHub 备份失败：${response.status}`, {
+      status: response.status,
+      retryable,
+    })
+  }
+
+  try {
+    const payload = (await response.json()) as {
+      content?: { path?: unknown; sha?: unknown; html_url?: unknown }
+      commit?: { sha?: unknown; html_url?: unknown }
+    }
+    const contentPath =
+      typeof payload.content?.path === 'string' ? payload.content.path : body.path?.toString?.() ?? ''
+    const contentSha = typeof payload.content?.sha === 'string' ? payload.content.sha : null
+    const commitSha = typeof payload.commit?.sha === 'string' ? payload.commit.sha : null
+    const htmlUrl = typeof payload.content?.html_url === 'string' ? payload.content.html_url : null
+    const commitUrl = typeof payload.commit?.html_url === 'string' ? payload.commit.html_url : null
+    return {
+      contentPath,
+      contentSha,
+      commitSha,
+      htmlUrl,
+      commitUrl,
+    }
+  } catch (error) {
+    console.warn('Failed to parse GitHub upload response', error)
+    return {
+      contentPath: typeof body.path === 'string' ? body.path : '',
+      contentSha: null,
+      commitSha: null,
+    }
+  }
+}
+
+export async function uploadGithubBackup(
+  config: GithubBackupConfig,
+  options: GithubBackupOptions = {},
+): Promise<GithubBackupResult> {
+  const fetchImpl = options.fetchImpl ?? (typeof fetch === 'function' ? fetch : null)
+  if (!fetchImpl) {
+    throw new GithubBackupError('当前环境不支持网络请求，请稍后重试。')
+  }
+
+  const token = ensureNonEmpty(config.token, 'GitHub 访问令牌')
+  const owner = ensureNonEmpty(config.owner, '仓库拥有者')
+  const repo = ensureNonEmpty(config.repo, '仓库名称')
+  const branch = ensureNonEmpty(config.branch || 'main', '分支')
+  const normalizedPath = normalizePath(config.path)
+  const content = config.content
+
+  const encodedOwner = encodeURIComponent(owner)
+  const encodedRepo = encodeURIComponent(repo)
+  const encodedPath = normalizedPath
+    .split('/')
+    .map(segment => encodeURIComponent(segment))
+    .join('/')
+  const endpoint = `${GITHUB_API_BASE_URL}/repos/${encodedOwner}/${encodedRepo}/contents/${encodedPath}`
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'Content-Type': 'application/json',
+  }
+
+  const maxRetries = Math.max(options.maxRetries ?? 1, 0)
+  const commitMessage = options.commitMessage ?? `Personal backup at ${new Date().toISOString()}`
+  const encodedContent = encodeBase64(content)
+
+  let attempt = 0
+  let lastError: unknown = null
+  while (attempt <= maxRetries) {
+    try {
+      const existingSha = await requestExistingSha(endpoint, branch, fetchImpl, headers)
+      const body: Record<string, unknown> = {
+        message: commitMessage,
+        branch,
+        content: encodedContent,
+        path: normalizedPath,
+      }
+      if (existingSha) {
+        body.sha = existingSha
+      }
+      return await uploadContent(endpoint, body, fetchImpl, headers)
+    } catch (error) {
+      lastError = error
+      if (error instanceof GithubBackupError && error.retryable && attempt < maxRetries) {
+        attempt += 1
+        continue
+      }
+      throw toGithubBackupError(error, '上传 GitHub 备份失败。')
+    }
+  }
+
+  throw toGithubBackupError(lastError, '上传 GitHub 备份失败。')
+}

--- a/tests/auth-github.test.ts
+++ b/tests/auth-github.test.ts
@@ -60,6 +60,9 @@ describe('GitHub account connection', () => {
     const decryptedToken = await decryptString(key as Uint8Array, record!.github!.tokenCipher)
     expect(decryptedToken).toBe(token)
     expect(record!.github!.username).toBe('octocat')
+    expect(record!.github!.repositoryOwner).toBeNull()
+    expect(record!.github!.repositoryName).toBeNull()
+    expect(record!.github!.targetDirectory).toBeNull()
 
     const profileGithub = useAuthStore.getState().profile?.github
     expect(profileGithub?.username).toBe('octocat')
@@ -69,6 +72,46 @@ describe('GitHub account connection', () => {
     const updatedRecord = await databaseClient.users.get(email)
     expect(updatedRecord?.github).toBeNull()
     expect(useAuthStore.getState().profile?.github).toBeNull()
+  })
+
+  it('persists GitHub repository configuration updates', async () => {
+    const auth = useAuthStore.getState()
+    const registerResult = await auth.register(email, password)
+    expect(registerResult.success).toBe(true)
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ login: 'octocat' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    const token = 'github_pat_UPDATE_REPO'
+    const connectResult = await useAuthStore.getState().connectGithub(token)
+    expect(connectResult.success).toBe(true)
+
+    const updateResult = await useAuthStore
+      .getState()
+      .updateGithubRepository({
+        owner: 'octo-org',
+        repo: 'personal-vault',
+        branch: 'backup',
+        targetDirectory: 'backups/pms-backup.json',
+      })
+    expect(updateResult.success).toBe(true)
+
+    const record = await databaseClient.users.get(email)
+    expect(record?.github?.repositoryOwner).toBe('octo-org')
+    expect(record?.github?.repositoryName).toBe('personal-vault')
+    expect(record?.github?.repositoryBranch).toBe('backup')
+    expect(record?.github?.targetDirectory).toBe('backups/pms-backup.json')
+
+    const profileGithub = useAuthStore.getState().profile?.github
+    expect(profileGithub?.repositoryOwner).toBe('octo-org')
+    expect(profileGithub?.repositoryName).toBe('personal-vault')
+    expect(profileGithub?.repositoryBranch).toBe('backup')
+    expect(profileGithub?.targetDirectory).toBe('backups/pms-backup.json')
   })
 
   it('rejects invalid GitHub tokens', async () => {

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -36,6 +36,7 @@ describe('sqlite database helpers', () => {
       mnemonic: 'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu',
       createdAt: now,
       updatedAt: now,
+      github: null,
     }
     await db.users.put(user)
     await expect(db.users.get('user@example.com')).resolves.toEqual(user)

--- a/tests/github-backup.test.ts
+++ b/tests/github-backup.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { uploadGithubBackup } from '../src/lib/github-backup'
+
+const successPayload = {
+  content: {
+    path: 'backups/pms-backup.json',
+    sha: 'content-sha',
+    html_url: 'https://github.com/octo-org/personal-vault/blob/main/backups/pms-backup.json',
+  },
+  commit: {
+    sha: 'commit-sha',
+    html_url: 'https://github.com/octo-org/personal-vault/commit/commit-sha',
+  },
+}
+
+describe('uploadGithubBackup', () => {
+  it('retries failed uploads before succeeding', async () => {
+    const responses: Response[] = [
+      new Response('Not Found', { status: 404 }),
+      new Response(JSON.stringify({ message: 'temporary failure' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      new Response('Not Found', { status: 404 }),
+      new Response(JSON.stringify(successPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ]
+
+    const fetchMock = vi.fn(async () => {
+      const next = responses.shift()
+      if (!next) {
+        throw new Error('No more responses')
+      }
+      return next
+    })
+
+    const result = await uploadGithubBackup(
+      {
+        token: 'ghp_testtoken',
+        owner: 'octo-org',
+        repo: 'personal-vault',
+        branch: 'main',
+        path: 'backups/pms-backup.json',
+        content: '{"demo":true}',
+      },
+      { fetchImpl: fetchMock as unknown as typeof fetch, maxRetries: 1, commitMessage: 'Test backup' },
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(result.contentPath).toBe('backups/pms-backup.json')
+    expect(result.commitSha).toBe('commit-sha')
+  })
+
+  it('throws with informative error after exhausting retries', async () => {
+    const failingFetch = vi
+      .fn(async () =>
+        new Response(JSON.stringify({ message: 'service unavailable' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockImplementationOnce(async () => new Response('Not Found', { status: 404 }))
+
+    await expect(
+      uploadGithubBackup(
+        {
+          token: 'ghp_testtoken',
+          owner: 'octo-org',
+          repo: 'personal-vault',
+          branch: 'main',
+          path: 'backups/pms-backup.json',
+          content: '{"demo":true}',
+        },
+        { fetchImpl: failingFetch as unknown as typeof fetch, maxRetries: 1 },
+      ),
+    ).rejects.toThrow('GitHub 备份失败：service unavailable')
+  })
+})


### PR DESCRIPTION
## Summary
- extend the GitHub connection model to persist repository owner/name/branch/path data across auth and SQLite layers
- add a GitHub backup uploader along with settings UI for repository configuration, status indicators, and auto-backup integration
- expand tests to cover GitHub connection persistence, backup uploader retries, and updated database expectations

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d41b48aec88331bea5a6d71715e484