### PR TITLE
Remove legacy repository path mirroring for inspiration notes

### DIFF
--- a/src/lib/inspiration-notes.ts
+++ b/src/lib/inspiration-notes.ts
@@ -2,7 +2,7 @@ import { mkdir, readDir, readTextFile, remove, writeTextFile } from '@tauri-apps
 import { appDataDir, join } from '@tauri-apps/api/path'
 
 import { isTauriRuntime } from '../env'
-import { DEFAULT_DATA_DIR_SEGMENTS, loadStoredDataPath, loadStoredRepositoryPath } from './storage-path'
+import { DEFAULT_DATA_DIR_SEGMENTS, loadStoredDataPath } from './storage-path'
 
 export const NOTES_DIR_NAME = 'notes'
 export const NOTE_FILE_EXTENSION = '.md'
@@ -561,22 +561,6 @@ export async function saveNote(draft: NoteDraft): Promise<NoteDetail> {
   const filePath = await join(targetDir, fileName)
   await writeTextFile(filePath, serialized)
 
-  const repositoryRoot = loadStoredRepositoryPath()
-  if (repositoryRoot) {
-    try {
-      const repositoryNotesDir = await join(repositoryRoot, NOTES_DIR_NAME)
-      const repositoryTargetDir =
-        directories.length > 0 ? await join(repositoryNotesDir, ...directories) : repositoryNotesDir
-      await mkdir(repositoryTargetDir, { recursive: true })
-      const repositoryFilePath = await join(repositoryTargetDir, fileName)
-      if (repositoryFilePath !== filePath) {
-        await writeTextFile(repositoryFilePath, serialized)
-      }
-    } catch (error) {
-      console.warn('Failed to synchronize inspiration note to repository path', error)
-    }
-  }
-
   const normalizedContent = normalizeContent(rawContent)
   const searchText = createSearchText(title, normalizedContent, tags)
 
@@ -628,22 +612,6 @@ export async function createNoteFile(titleOrPath: string): Promise<string> {
   const serialized = serializeNoteFile({ title, createdAt: now, updatedAt: now, tags: [] }, '')
   await writeTextFile(filePath, serialized)
 
-  const repositoryRoot = loadStoredRepositoryPath()
-  if (repositoryRoot) {
-    try {
-      const repositoryNotesDir = await join(repositoryRoot, NOTES_DIR_NAME)
-      const repositoryTargetDir =
-        directories.length > 0 ? await join(repositoryNotesDir, ...directories) : repositoryNotesDir
-      await mkdir(repositoryTargetDir, { recursive: true })
-      const repositoryFilePath = await join(repositoryTargetDir, fileName)
-      if (repositoryFilePath !== filePath) {
-        await writeTextFile(repositoryFilePath, serialized)
-      }
-    } catch (error) {
-      console.warn('Failed to synchronize inspiration note to repository path', error)
-    }
-  }
-
   return notePath
 }
 
@@ -654,20 +622,6 @@ export async function createNoteFolder(path: string): Promise<string> {
   const segments = sanitized.split('/').filter(Boolean)
   const targetDir = segments.length > 0 ? await join(dir, ...segments) : dir
   await mkdir(targetDir, { recursive: true })
-
-  const repositoryRoot = loadStoredRepositoryPath()
-  if (repositoryRoot) {
-    try {
-      const repositoryNotesDir = await join(repositoryRoot, NOTES_DIR_NAME)
-      const repositoryTargetDir =
-        segments.length > 0 ? await join(repositoryNotesDir, ...segments) : repositoryNotesDir
-      if (repositoryTargetDir !== targetDir) {
-        await mkdir(repositoryTargetDir, { recursive: true })
-      }
-    } catch (error) {
-      console.warn('Failed to create repository folder for inspiration notes', error)
-    }
-  }
 
   return sanitized
 }
@@ -687,24 +641,4 @@ export async function deleteNote(id: string): Promise<void> {
     }
   }
 
-  const repositoryRoot = loadStoredRepositoryPath()
-  if (repositoryRoot) {
-    try {
-      const repositoryNotesDir = await join(repositoryRoot, NOTES_DIR_NAME)
-      const repositoryTargetDir =
-        directories.length > 0 ? await join(repositoryNotesDir, ...directories) : repositoryNotesDir
-      const repositoryFilePath = await join(repositoryTargetDir, fileName)
-      if (repositoryFilePath !== filePath) {
-        try {
-          await remove(repositoryFilePath)
-        } catch (error) {
-          if (!isMissingFsEntryError(error)) {
-            throw error
-          }
-        }
-      }
-    } catch (error) {
-      console.warn('Failed to remove repository note copy', error)
-    }
-  }
 }

--- a/src/lib/storage-path.ts
+++ b/src/lib/storage-path.ts
@@ -1,5 +1,4 @@
 export const DATA_PATH_STORAGE_KEY = 'pms-data-path'
-export const REPOSITORY_PATH_STORAGE_KEY = 'pms-repo-path'
 export const DEFAULT_DATA_DIR_SEGMENTS = ['data'] as const
 export const DATABASE_FILE_NAME = 'pms.db'
 
@@ -30,29 +29,3 @@ export function saveStoredDataPath(path: string | null): void {
   }
 }
 
-export function loadStoredRepositoryPath(): string | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const stored = window.localStorage.getItem(REPOSITORY_PATH_STORAGE_KEY)
-    if (typeof stored === 'string') {
-      const normalized = stored.trim()
-      return normalized ? normalized : null
-    }
-  } catch (error) {
-    console.warn('Failed to read persisted repository path', error)
-  }
-  return null
-}
-
-export function saveStoredRepositoryPath(path: string | null): void {
-  if (typeof window === 'undefined') return
-  try {
-    if (path && path.trim()) {
-      window.localStorage.setItem(REPOSITORY_PATH_STORAGE_KEY, path)
-    } else {
-      window.localStorage.removeItem(REPOSITORY_PATH_STORAGE_KEY)
-    }
-  } catch (error) {
-    console.warn('Failed to persist repository path', error)
-  }
-}


### PR DESCRIPTION
## Summary
- remove the legacy inspiration note repository mirror controls from settings and clear the old localStorage key on load
- drop repository path persistence helpers and keep inspiration note storage scoped to the ensureNotesDirectory location
- refresh inspiration note tests to cover the local directory expectations only

## Testing
- pnpm test -- tests/inspiration-notes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d461a690248331b34420f07859d04a