### PR TITLE
Add repository path storage helpers

### DIFF
--- a/src/lib/inspiration-notes.ts
+++ b/src/lib/inspiration-notes.ts
@@ -2,7 +2,11 @@ import { mkdir, readDir, readTextFile, remove, writeTextFile } from '@tauri-apps
 import { appDataDir, join } from '@tauri-apps/api/path'
 
 import { isTauriRuntime } from '../env'
-import { DEFAULT_DATA_DIR_SEGMENTS, loadStoredDataPath } from './storage-path'
+import {
+  DEFAULT_DATA_DIR_SEGMENTS,
+  loadStoredDataPath,
+  loadStoredRepositoryPath,
+} from './storage-path'
 
 export const NOTES_DIR_NAME = 'notes'
 export const NOTE_FILE_EXTENSION = '.md'

--- a/src/lib/storage-path.ts
+++ b/src/lib/storage-path.ts
@@ -1,4 +1,5 @@
 export const DATA_PATH_STORAGE_KEY = 'pms-data-path'
+export const REPOSITORY_PATH_STORAGE_KEY = 'pms-repository-path'
 export const DEFAULT_DATA_DIR_SEGMENTS = ['data'] as const
 export const DATABASE_FILE_NAME = 'pms.db'
 
@@ -26,6 +27,43 @@ export function saveStoredDataPath(path: string | null): void {
     }
   } catch (error) {
     console.warn('Failed to persist data path', error)
+  }
+}
+
+export function loadStoredRepositoryPath(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const stored = window.localStorage.getItem(REPOSITORY_PATH_STORAGE_KEY)
+    if (typeof stored === 'string') {
+      const normalized = stored.trim()
+      if (normalized) {
+        return normalized
+      }
+    }
+
+    const legacy = window.localStorage.getItem('pms-repo-path')
+    if (typeof legacy === 'string') {
+      const normalizedLegacy = legacy.trim()
+      if (normalizedLegacy) {
+        return normalizedLegacy
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to read persisted repository path', error)
+  }
+  return null
+}
+
+export function saveStoredRepositoryPath(path: string | null): void {
+  if (typeof window === 'undefined') return
+  try {
+    if (path && path.trim()) {
+      window.localStorage.setItem(REPOSITORY_PATH_STORAGE_KEY, path.trim())
+    } else {
+      window.localStorage.removeItem(REPOSITORY_PATH_STORAGE_KEY)
+    }
+  } catch (error) {
+    console.warn('Failed to persist repository path', error)
   }
 }
 


### PR DESCRIPTION
## Summary
- add repository path storage helpers with legacy fallback
- update inspiration notes backup restore to use repository path helper

## Testing
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d4655a8e888331a1a1c0bf59756194