### PR TITLE
feat: add type declarations for tauri dialog plugin

### DIFF
--- a/src/types/tauri-plugin-dialog.d.ts
+++ b/src/types/tauri-plugin-dialog.d.ts
@@ -1,0 +1,9 @@
+declare module '@tauri-apps/plugin-dialog' {
+  export type {
+    DialogFilter,
+    OpenDialogOptions,
+    SaveDialogOptions,
+  } from '@tauri-apps/api/dialog'
+
+  export { open, save } from '@tauri-apps/api/dialog'
+}


### PR DESCRIPTION
## Summary
- add ambient module declarations for `@tauri-apps/plugin-dialog`
- re-export dialog option types and open/save functions from `@tauri-apps/api/dialog`

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4eb6439748331bbd80b4967283368