### PR TITLE
Add dialog plugin type stub

### DIFF
--- a/src/types/tauri-plugin-dialog.d.ts
+++ b/src/types/tauri-plugin-dialog.d.ts
@@ -3,7 +3,6 @@ declare module '@tauri-apps/plugin-dialog' {
     DialogFilter,
     OpenDialogOptions,
     SaveDialogOptions,
-  } from '@tauri-apps/api/dialog'
-
-  export { open, save } from '@tauri-apps/api/dialog'
+  } from '@tauri-apps/api/dialog';
+  export { open, save } from '@tauri-apps/api/dialog';
 }


### PR DESCRIPTION
## Summary
- add a declaration file for the `@tauri-apps/plugin-dialog` module that re-exports dialog types and APIs

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4f4f6ba348331ae1ba30d350c38be