### PR TITLE
Refactor Tauri dialog wrapper to invoke plugin directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@noble/ciphers": "^1.3.0",
     "@tanstack/react-query": "^5.89.0",
     "@tauri-apps/api": "^2.0.0",
-    "@tauri-apps/plugin-dialog": "^2.4.0",
     "@tauri-apps/plugin-fs": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@tauri-apps/plugin-sql": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.8.0(patch_hash=54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e)
-      '@tauri-apps/plugin-dialog':
-        specifier: ^2.4.0
-        version: 2.4.0
       '@tauri-apps/plugin-fs':
         specifier: ^2.0.0
         version: 2.4.2
@@ -1195,9 +1192,6 @@ packages:
     resolution: {integrity: sha512-ejUZBzuQRcjFV+v/gdj/DcbyX/6T4unZQjMSBZwLzP/CymEjKcc2+Fc8xTORThebHDUvqoXMdsCZt8r+hyN15g==}
     engines: {node: '>= 10'}
     hasBin: true
-
-  '@tauri-apps/plugin-dialog@2.4.0':
-    resolution: {integrity: sha512-OvXkrEBfWwtd8tzVCEXIvRfNEX87qs2jv6SqmVPiHcJjBhSF/GUvjqUNIDmKByb5N8nvDqVUM7+g1sXwdC/S9w==}
 
   '@tauri-apps/plugin-fs@2.4.2':
     resolution: {integrity: sha512-YGhmYuTgXGsi6AjoV+5mh2NvicgWBfVJHHheuck6oHD+HC9bVWPaHvCP0/Aw4pHDejwrvT8hE3+zZAaWf+hrig==}
@@ -4669,10 +4663,6 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.8.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.8.4
       '@tauri-apps/cli-win32-x64-msvc': 2.8.4
-
-  '@tauri-apps/plugin-dialog@2.4.0':
-    dependencies:
-      '@tauri-apps/api': 2.8.0(patch_hash=54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e)
 
   '@tauri-apps/plugin-fs@2.4.2':
     dependencies:

--- a/src/lib/tauri-dialog.ts
+++ b/src/lib/tauri-dialog.ts
@@ -1,10 +1,21 @@
-import {
-  open,
-  save,
-  type DialogFilter,
-  type OpenDialogOptions,
-  type SaveDialogOptions,
-} from '@tauri-apps/plugin-dialog'
+import { invoke } from '@tauri-apps/api/core'
+
+export type DialogFilter = {
+  name?: string
+  extensions: string[]
+}
+
+export type OpenDialogOptions = {
+  defaultPath?: string
+  filters?: DialogFilter[]
+  multiple?: boolean
+  directory?: boolean
+}
+
+export type SaveDialogOptions = {
+  defaultPath?: string
+  filters?: DialogFilter[]
+}
 
 type MaybeTauriWindow = Window & {
   __TAURI__?: {
@@ -40,14 +51,12 @@ const ensureTauriDialogAvailable = (): void => {
   throw new Error('Tauri dialog API is not available in this environment')
 }
 
-export type { DialogFilter, OpenDialogOptions, SaveDialogOptions }
-
 export const openDialog = async (options?: OpenDialogOptions) => {
   ensureTauriDialogAvailable()
-  return open(options)
+  return invoke<string | string[] | null>('plugin:dialog|open', { options })
 }
 
 export const saveDialog = async (options?: SaveDialogOptions) => {
   ensureTauriDialogAvailable()
-  return save(options)
+  return invoke<string | null>('plugin:dialog|save', { options })
 }

--- a/src/types/tauri-plugin-dialog.d.ts
+++ b/src/types/tauri-plugin-dialog.d.ts
@@ -1,8 +1,0 @@
-declare module '@tauri-apps/plugin-dialog' {
-  export type {
-    DialogFilter,
-    OpenDialogOptions,
-    SaveDialogOptions,
-  } from '@tauri-apps/api/dialog';
-  export { open, save } from '@tauri-apps/api/dialog';
-}


### PR DESCRIPTION
## Summary
- inline the Tauri dialog option types and call the dialog plugin via `invoke`
- remove the `@tauri-apps/plugin-dialog` dependency and its augmentation stub
- refresh the pnpm lockfile after dropping the plugin package

## Testing
- VITE_DESKTOP=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4f9347d548331896eaa3320ac5b37