### PR TITLE
fix: remove Node Buffer usage from notes stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,21 @@
   "dependencies": {
     "@noble/ciphers": "^1.3.0",
     "@tanstack/react-query": "^5.89.0",
+    "@tiptap/core": "^2.7.4",
+    "@tiptap/extension-character-count": "^2.6.0",
+    "@tiptap/extension-heading": "^2.6.0",
+    "@tiptap/pm": "^2.7.4",
+    "@tiptap/react": "^2.7.4",
+    "@tiptap/starter-kit": "^2.6.0",
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-fs": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@tauri-apps/plugin-sql": "^2.0.0",
     "clsx": "^2.1.1",
     "dexie": "^4.2.0",
     "fuse.js": "^7.0.0",
+    "gray-matter": "^4.0.3",
     "hash-wasm": "^4.12.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.454.0",
@@ -38,6 +46,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.26.2",
+    "tiptap-markdown": "^0.8.8",
     "sql.js": "^1.10.2",
     "zustand": "^4.5.2"
   },
@@ -69,10 +78,5 @@
     "vite": "^5.4.2",
     "vite-plugin-pwa": "^1.0.3",
     "vitest": "^3.2.4"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "@tauri-apps/api": "patches/@tauri-apps__api.patch"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-patchedDependencies:
-  '@tauri-apps/api':
-    hash: 54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e
-    path: patches/@tauri-apps__api.patch
-
 importers:
 
   .:
@@ -21,7 +16,10 @@ importers:
         version: 5.89.0(react@18.3.1)
       '@tauri-apps/api':
         specifier: ^2.0.0
-        version: 2.8.0(patch_hash=54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e)
+        version: 2.8.0
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.0.0
+        version: 2.3.0
       '@tauri-apps/plugin-fs':
         specifier: ^2.0.0
         version: 2.4.2
@@ -31,6 +29,24 @@ importers:
       '@tauri-apps/plugin-sql':
         specifier: ^2.0.0
         version: 2.3.0
+      '@tiptap/core':
+        specifier: ^2.7.4
+        version: 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/extension-character-count':
+        specifier: ^2.6.0
+        version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/extension-heading':
+        specifier: ^2.6.0
+        version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/pm':
+        specifier: ^2.7.4
+        version: 2.26.2
+      '@tiptap/react':
+        specifier: ^2.7.4
+        version: 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tiptap/starter-kit':
+        specifier: ^2.6.0
+        version: 2.26.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -40,6 +56,9 @@ importers:
       fuse.js:
         specifier: ^7.0.0
         version: 7.1.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       hash-wasm:
         specifier: ^4.12.0
         version: 4.12.0
@@ -70,6 +89,9 @@ importers:
       sql.js:
         specifier: ^1.10.2
         version: 1.13.0
+      tiptap-markdown:
+        specifier: ^0.8.8
+        version: 0.8.10(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
       zustand:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@18.3.24)(react@18.3.1)
@@ -947,6 +969,12 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@remirror/core-constants@3.0.0':
+    resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
+
   '@remix-run/router@1.23.0':
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
@@ -1193,6 +1221,9 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@tauri-apps/plugin-clipboard-manager@2.3.0':
+    resolution: {integrity: sha512-81NOBA2P+OTY8RLkBwyl9ZR/0CeggLub4F6zxcxUIfFOAqtky7J61+K/MkH2SC1FMxNBxrX0swDuKvkjkHadlA==}
+
   '@tauri-apps/plugin-fs@2.4.2':
     resolution: {integrity: sha512-YGhmYuTgXGsi6AjoV+5mh2NvicgWBfVJHHheuck6oHD+HC9bVWPaHvCP0/Aw4pHDejwrvT8hE3+zZAaWf+hrig==}
 
@@ -1222,6 +1253,143 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tiptap/core@2.26.2':
+    resolution: {integrity: sha512-cr30QWJECl5j7qUUG4Z4BDitHgJIBWipbC3JbjoDtumgZLedGa5SV+JiGa4GUhNt9E34Pw1BH0gBDL4adGHiLg==}
+    peerDependencies:
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-blockquote@2.26.2':
+    resolution: {integrity: sha512-SQNMX2rkWdAOYT6pM9KZ4bZK07YiCqX6wkHiKbLSZ8GMLi35dhkiSBxvY2I72q5ucIjgC9asGf8knA/2fbVypA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-bold@2.26.2':
+    resolution: {integrity: sha512-kNjbHZhLyDu2ZBZmJINzXg3MAW7+05KqGkcwxudC1X/DQM5V5FpW7u6TOlC+nf1I9wABgayxURyU8FsIaXDxqA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-bubble-menu@2.26.2':
+    resolution: {integrity: sha512-kB7/bGTUnC7ZCBH/fkigpfId925nwGOn+Nq1hf199NYMu2ffWbKk75ckLwyqlETprQYzzHfViIqcwyxJzo04Sg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-bullet-list@2.26.2':
+    resolution: {integrity: sha512-L0qxUa5vzUciLEVtr1nY6HG8gH8432GtuX807MM/5wKiYYdbSii3I22456ZnboiozoqXrjjvYUHeB++HhOSPgQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-character-count@2.26.2':
+    resolution: {integrity: sha512-N9gcFmFcy+OzxO5wzO/VLvXzjVss4Nyc3zHjCD38W9p4kFzX+I1cDad8tjolpvjvun+UZsLEm2YIWnHbZNwc2Q==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-code-block@2.26.2':
+    resolution: {integrity: sha512-MJZ4QtziIWJ1zuSW2ogAHv+UHGk3DvGbVi+Dfmo0ybonXX7vRVHE+3qT7OcdTRBF+pC2oCnsjzqwFcGBP3BbZw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-code@2.26.2':
+    resolution: {integrity: sha512-xnKJvzlAp75dheyaK5tLKAksHf9PtSr8a7OuPjf2IXS5K+QMtnwxx7KAHHijmecfWjLR0wyu9AvT/FWFfKi5LQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-document@2.26.2':
+    resolution: {integrity: sha512-s0/P3A8zxWL/h3e20xWMTT/rcwD0+57I6mT9JgNBPtvhPePy8d698G6/qFK+x+GdIyjJylfsq2BrSE9H+QhIBg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-dropcursor@2.26.2':
+    resolution: {integrity: sha512-o5j4Gkurb/WBu1wP2tihYnZ8dENzmlxFWWMx++g6abEpn9xdud7VxHT5Ny7mBSBptI8uMwKT53weYC0on38n3g==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-floating-menu@2.26.2':
+    resolution: {integrity: sha512-AILrhwKAGU4Z6GcjNXJAsN0LHlL26bE7VRrYIqUwDv44ImiQf5vu9jEnncBOeHWzMe8SgjrrJWGNNu+dceACpw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-gapcursor@2.26.2':
+    resolution: {integrity: sha512-a68mi8V0mh058UrBIk23f50K5JGVeRZnF6ViptIleAD/Ny1K6VLjGCz6k190de+Tb9tnQLPEwwwDcy+ZnvCmYQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-hard-break@2.26.2':
+    resolution: {integrity: sha512-OLpeTey7p3ChyEsABLPvNv7rD/8E4k1JTt+H+MUjyL0dnrZuIWluckUJCJKnV8PhR9Mifngk1MTFUilpooiv1g==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-heading@2.26.2':
+    resolution: {integrity: sha512-0VAr1l1QKFJ0B2l4D4wV0LRlyFYeJt0S09mz+HPF2TqKF4twmPjaGD6o5zzXWl8c4cQj1CmM8P+9an3SKRjOaA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-history@2.26.2':
+    resolution: {integrity: sha512-X/cu79AV5D2Z1QtuvKo/4/Rgl/Uti/n5V3QgCxFLQRCKTxHOCis+RlBCjBfOPztJX4T9QUE6lq20KqB47rsNwQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-horizontal-rule@2.26.2':
+    resolution: {integrity: sha512-whlUskFUwmi7nXn4OT55xHXSAqwEAEQfZWswmae1Y5wTMDxavZ0FF4xvCVgsQ7gYG782tIgLCzriTN4AjBphIQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-italic@2.26.2':
+    resolution: {integrity: sha512-/4AiE2JWtjY9yW+MifMP8EOOwOSDKDUxCyqtGT6e4xqqFUNLZJA0o4P/MYjcKVwsa1/IsDRsOaFRlAiMmAXVXw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-list-item@2.26.2':
+    resolution: {integrity: sha512-T1dFfx1JjRRX0iyStSTwMNajMyT+OE7XEggn+DON1g+zbgA+4cJ11WQpfrfA9VM2H5QWYyKGfHFigoFcJ8rjog==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-ordered-list@2.26.2':
+    resolution: {integrity: sha512-UVGYyWKB5wWWvrvdN/WrPXPHJoP/UD1TNyeoE75M6nq4oD4l+Nc9Y5MIPsngrv/TimbomLNilR4ZRHibEriG9w==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-paragraph@2.26.2':
+    resolution: {integrity: sha512-dccyffm95nNT9arjxGOyv4/cOPF4XS5Osylccp9KYLrmiSTXEuzVIYtMXhXbc0UUdABGvbFQWi88tRxgeDTkgA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-strike@2.26.2':
+    resolution: {integrity: sha512-gY8/P8ycvICiZsa9OeTpOnSL0o+PAYH1QpBomaBhdZZ2tcsziMYN9BZto6uQARi9tdxeOYRePyZ+Junk4xsyFg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-text-style@2.26.2':
+    resolution: {integrity: sha512-rNkV3dgT3nTISEf3Ax/DdqQsSy9p46n2fOBkD8FCtdrwsWNH5N4uUh4jI/q0exYKJUyZGvl60uXwCkZiQ3pVBA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-text@2.26.2':
+    resolution: {integrity: sha512-Rb8Le/Li+EixQNc/pGkEJpLjozTjWYP9glaYfnjPtRVw4tHcd7khVm5mer0TQjonbBUjVC1zSuXv9gifXOv6DQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/pm@2.26.2':
+    resolution: {integrity: sha512-H2kJHckC9idlYPu/PNdu5XR3Rdu7gbNb+Qrdt2gBnaDyHgAcs+14wak6x19vy27GV9FFzg9722Eb7LErooo28w==}
+
+  '@tiptap/react@2.26.2':
+    resolution: {integrity: sha512-p7jv0sltCC2L4iHIVNthtjv/CIxajOalb7ytjLx6ijx5q2J564VIny0U7O33Ymbo2cV0dJoB+Bo5aeaJ5SfHGg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@2.26.1':
+    resolution: {integrity: sha512-oziMGCds8SVQ3s5dRpBxVdEKZAmO/O//BjZ69mhA3q4vJdR0rnfLb5fTxSeQvHiqB878HBNn76kNaJrHrV35GA==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1262,8 +1430,26 @@ packages:
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1296,6 +1482,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.44.0':
     resolution: {integrity: sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==}
@@ -1443,6 +1632,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1645,6 +1837,9 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -1782,6 +1977,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -1877,6 +2076,11 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -1908,6 +2112,10 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2055,6 +2263,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2205,6 +2417,10 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2337,6 +2553,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -2397,6 +2617,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -2414,6 +2638,9 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2466,6 +2693,13 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2496,6 +2730,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2660,6 +2897,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -2811,6 +3051,68 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  prosemirror-changeset@2.3.1:
+    resolution: {integrity: sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.3.2:
+    resolution: {integrity: sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==}
+
+  prosemirror-history@1.4.1:
+    resolution: {integrity: sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==}
+
+  prosemirror-inputrules@1.5.0:
+    resolution: {integrity: sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.2:
+    resolution: {integrity: sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==}
+
+  prosemirror-menu@1.2.5:
+    resolution: {integrity: sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==}
+
+  prosemirror-model@1.25.3:
+    resolution: {integrity: sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.3:
+    resolution: {integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==}
+
+  prosemirror-tables@1.8.1:
+    resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
+
+  prosemirror-trailing-node@3.0.0:
+    resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+
+  prosemirror-transform@1.10.4:
+    resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
+
+  prosemirror-view@1.41.1:
+    resolution: {integrity: sha512-cViIhlt1/T5bQMINrmXh43JZcdIgdW1YkOABmIuH5gSt3/HiCZHsLN9d5GvsgzrXn2+zZ8il0kkghisusm7tSA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2941,6 +3243,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -2974,6 +3279,10 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3059,6 +3368,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   sql.js@1.13.0:
     resolution: {integrity: sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==}
 
@@ -3116,6 +3428,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-comments@2.0.1:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
@@ -3204,6 +3520,14 @@ packages:
     resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
+  tippy.js@6.3.7:
+    resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
+
+  tiptap-markdown@0.8.10:
+    resolution: {integrity: sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.3
+
   tldts-core@7.0.14:
     resolution: {integrity: sha512-viZGNK6+NdluOJWwTO9olaugx0bkKhscIdriQQ+lNNhwitIKvb+SvhbYgnCz6j9p7dX3cJntt4agQAKMXLjJ5g==}
 
@@ -3273,6 +3597,9 @@ packages:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -3425,6 +3752,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -4484,6 +4814,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@popperjs/core@2.11.8': {}
+
+  '@remirror/core-constants@3.0.0': {}
+
   '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -4615,7 +4949,7 @@ snapshots:
       '@tanstack/query-core': 5.89.0
       react: 18.3.1
 
-  '@tauri-apps/api@2.8.0(patch_hash=54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e)': {}
+  '@tauri-apps/api@2.8.0': {}
 
   '@tauri-apps/cli-darwin-arm64@2.8.4':
     optional: true
@@ -4664,17 +4998,21 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.8.4
       '@tauri-apps/cli-win32-x64-msvc': 2.8.4
 
+  '@tauri-apps/plugin-clipboard-manager@2.3.0':
+    dependencies:
+      '@tauri-apps/api': 2.8.0
+
   '@tauri-apps/plugin-fs@2.4.2':
     dependencies:
-      '@tauri-apps/api': 2.8.0(patch_hash=54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e)
+      '@tauri-apps/api': 2.8.0
 
   '@tauri-apps/plugin-shell@2.3.1':
     dependencies:
-      '@tauri-apps/api': 2.8.0(patch_hash=54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e)
+      '@tauri-apps/api': 2.8.0
 
   '@tauri-apps/plugin-sql@2.3.0':
     dependencies:
-      '@tauri-apps/api': 2.8.0(patch_hash=54143f80fce915f1cb2b409de8eeaa901536809832a63724c31a8c071ca00a7e)
+      '@tauri-apps/api': 2.8.0
 
   '@testing-library/dom@9.3.4':
     dependencies:
@@ -4709,6 +5047,165 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@9.3.4)':
     dependencies:
       '@testing-library/dom': 9.3.4
+
+  '@tiptap/core@2.26.2(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/pm': 2.26.2
+
+  '@tiptap/extension-blockquote@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-bold@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-bubble-menu@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+      tippy.js: 6.3.7
+
+  '@tiptap/extension-bullet-list@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-character-count@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+
+  '@tiptap/extension-code-block@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+
+  '@tiptap/extension-code@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-document@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-dropcursor@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+
+  '@tiptap/extension-floating-menu@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+      tippy.js: 6.3.7
+
+  '@tiptap/extension-gapcursor@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+
+  '@tiptap/extension-hard-break@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-heading@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-history@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+
+  '@tiptap/extension-horizontal-rule@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+
+  '@tiptap/extension-italic@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-list-item@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-ordered-list@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-paragraph@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-strike@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-text-style@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/extension-text@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+
+  '@tiptap/pm@2.26.2':
+    dependencies:
+      prosemirror-changeset: 2.3.1
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.3.2
+      prosemirror-history: 1.4.1
+      prosemirror-inputrules: 1.5.0
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.2
+      prosemirror-menu: 1.2.5
+      prosemirror-model: 1.25.3
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.3
+      prosemirror-tables: 1.8.1
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.1)
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.1
+
+  '@tiptap/react@2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/extension-bubble-menu': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/extension-floating-menu': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/pm': 2.26.2
+      '@types/use-sync-external-store': 0.0.6
+      fast-deep-equal: 3.1.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.5.0(react@18.3.1)
+
+  '@tiptap/starter-kit@2.26.1':
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@tiptap/extension-blockquote': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-bold': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-bullet-list': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-code': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-code-block': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/extension-document': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-dropcursor': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/extension-gapcursor': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/extension-hard-break': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-heading': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-history': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/extension-horizontal-rule': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))(@tiptap/pm@2.26.2)
+      '@tiptap/extension-italic': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-list-item': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-ordered-list': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-paragraph': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-strike': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-text': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/extension-text-style': 2.26.2(@tiptap/core@2.26.2(@tiptap/pm@2.26.2))
+      '@tiptap/pm': 2.26.2
 
   '@types/aria-query@5.0.4': {}
 
@@ -4761,9 +5258,27 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
+  '@types/linkify-it@3.0.5': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@1.0.5': {}
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 
@@ -4791,6 +5306,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
@@ -4983,6 +5500,10 @@ snapshots:
       picomatch: 2.3.1
 
   arg@5.0.2: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -5213,6 +5734,8 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  crelt@1.0.6: {}
+
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.6
@@ -5357,6 +5880,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -5593,6 +6118,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 3.4.3
 
+  esprima@4.0.1: {}
+
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
@@ -5616,6 +6143,10 @@ snapshots:
   esutils@2.0.3: {}
 
   expect-type@1.2.2: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   extend@3.0.2: {}
 
@@ -5776,6 +6307,13 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   has-bigints@1.1.0: {}
 
@@ -5941,6 +6479,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -6059,6 +6599,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -6133,6 +6678,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kind-of@6.0.3: {}
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -6147,6 +6694,10 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
 
   locate-path@6.0.0:
     dependencies:
@@ -6189,6 +6740,17 @@ snapshots:
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
 
@@ -6282,6 +6844,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.12.2: {}
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -6515,6 +7079,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  orderedmap@2.1.1: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -6642,6 +7208,111 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  prosemirror-changeset@2.3.1:
+    dependencies:
+      prosemirror-transform: 1.10.4
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.3
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.1
+
+  prosemirror-gapcursor@1.3.2:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.1
+
+  prosemirror-history@1.4.1:
+    dependencies:
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.1
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.3
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.2:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.0
+      prosemirror-model: 1.25.3
+
+  prosemirror-menu@1.2.5:
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.4.1
+      prosemirror-state: 1.4.3
+
+  prosemirror-model@1.25.3:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.3
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  prosemirror-state@1.4.3:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.1
+
+  prosemirror-tables@1.8.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.1
+
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.1):
+    dependencies:
+      '@remirror/core-constants': 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.1
+
+  prosemirror-transform@1.10.4:
+    dependencies:
+      prosemirror-model: 1.25.3
+
+  prosemirror-view@1.41.1:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -6831,6 +7502,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.50.0
       fsevents: 2.3.3
 
+  rope-sequence@1.3.4: {}
+
   rrweb-cssom@0.8.0: {}
 
   run-parallel@1.2.0:
@@ -6869,6 +7542,11 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
 
   semver@6.3.1: {}
 
@@ -6959,6 +7637,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sprintf-js@1.0.3: {}
+
   sql.js@1.13.0: {}
 
   stackback@0.0.2: {}
@@ -7048,6 +7728,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.2.0
+
+  strip-bom-string@1.0.0: {}
 
   strip-comments@2.0.1: {}
 
@@ -7155,6 +7837,18 @@ snapshots:
 
   tinyspy@4.0.3: {}
 
+  tippy.js@6.3.7:
+    dependencies:
+      '@popperjs/core': 2.11.8
+
+  tiptap-markdown@0.8.10(@tiptap/core@2.26.2(@tiptap/pm@2.26.2)):
+    dependencies:
+      '@tiptap/core': 2.26.2(@tiptap/pm@2.26.2)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.1.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.2
+
   tldts-core@7.0.14: {}
 
   tldts@7.0.14:
@@ -7229,6 +7923,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.2: {}
+
+  uc.micro@2.1.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -7395,6 +8091,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6,10 +6,12 @@ version = 4
 name = "Personal"
 version = "0.1.0"
 dependencies = [
+ "notify",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-shell",
@@ -76,6 +78,27 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.1",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
 
 [[package]]
 name = "ashpd"
@@ -291,6 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +454,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -564,6 +602,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -915,6 +959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1003,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,10 +1042,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1044,6 +1132,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1272,6 +1369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1564,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1658,7 +1775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1775,6 +1892,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.0",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1934,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1946,6 +2097,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2204,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2131,6 +2308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,6 +2325,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -2149,6 +2344,16 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2166,7 +2371,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.16",
  "windows-sys 0.60.2",
@@ -2226,6 +2431,35 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-bigint-dig"
@@ -2296,7 +2530,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -2668,6 +2902,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.11.1",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +3111,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.9.4",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,6 +3220,21 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3279,6 +3551,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -3286,7 +3571,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.0",
 ]
 
@@ -4209,7 +4494,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4254,6 +4539,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.5",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adddd9e9275b20e77af3061d100a25a884cced3c4c9ef680bd94dd0f7e26c1ca"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -4445,7 +4745,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.0",
 ]
 
@@ -4498,6 +4798,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4565,7 +4879,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.4",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -4799,10 +5113,22 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.1",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.16",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f943391d896cdfe8eec03a04d7110332d445be7df856db382dd96a730667562c"
+dependencies = [
+ "memchr",
+ "nom",
+ "once_cell",
+ "petgraph",
 ]
 
 [[package]]
@@ -5142,7 +5468,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.2",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -5155,7 +5481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.4",
- "rustix",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5169,6 +5495,19 @@ dependencies = [
  "bitflags 2.9.4",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+dependencies = [
+ "bitflags 2.9.4",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5283,6 +5622,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "whoami"
@@ -5820,6 +6165,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5ff8d0e60065f549fafd9d6cb626203ea64a798186c80d8e7df4f8af56baeb"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 0.38.44",
+ "tempfile",
+ "thiserror 2.0.16",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5890,6 +6254,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.2",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -6048,6 +6429,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,10 +11,12 @@ tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-clipboard-manager = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+notify = "6"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build();
+    tauri_build::build();
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,11 +1,31 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod notes;
+
+use std::path::PathBuf;
+
+use notes::{set_notes_root, NotesWatcherState};
+use tauri::Manager;
+
 fn main() {
-  tauri::Builder::default()
-    .plugin(tauri_plugin_dialog::init())
-    .plugin(tauri_plugin_fs::init())
-    .plugin(tauri_plugin_sql::Builder::default().build())
-    .plugin(tauri_plugin_shell::init())
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    tauri::Builder::default()
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_sql::Builder::default().build())
+        .plugin(tauri_plugin_shell::init())
+        .manage(NotesWatcherState::default())
+        .invoke_handler(tauri::generate_handler![set_notes_root])
+        .setup(|app| {
+            if let Ok(root) = std::env::var("NOTES_ROOT") {
+                if !root.trim().is_empty() {
+                    let handle = app.handle();
+                    let state = app.state::<NotesWatcherState>();
+                    let _ = state.set_root(&handle, PathBuf::from(root));
+                }
+            }
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -1,0 +1,101 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use notify::{RecommendedWatcher, RecursiveMode, Result as NotifyResult, Watcher};
+use tauri::{AppHandle, State};
+
+#[derive(Default)]
+pub struct NotesWatcherState {
+    inner: Mutex<Option<WatcherGuard>>,
+}
+
+struct WatcherGuard {
+    root: PathBuf,
+    watcher: Option<RecommendedWatcher>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl WatcherGuard {
+    fn stop(&mut self) {
+        if let Some(mut watcher) = self.watcher.take() {
+            let _ = watcher.unwatch(Path::new(&self.root));
+        }
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for WatcherGuard {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+pub fn spawn_fs_watcher(app_handle: AppHandle, root: PathBuf) -> NotifyResult<WatcherGuard> {
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let mut watcher = RecommendedWatcher::new(tx, notify::Config::default())?;
+    watcher.watch(Path::new(&root), RecursiveMode::Recursive)?;
+
+    let thread = std::thread::spawn(move || {
+        for result in rx {
+            match result {
+                Ok(event) => {
+                    let payload = serde_json::to_string(
+                        &event
+                            .paths
+                            .into_iter()
+                            .filter_map(|path| path.to_str().map(|value| value.to_string()))
+                            .collect::<Vec<String>>(),
+                    )
+                    .unwrap_or_else(|_| "[]".to_string());
+                    let _ = app_handle.emit("notes://fs", payload);
+                }
+                Err(err) => {
+                    let payload = format!(r#"{{"error":"{}"}}"#, err);
+                    let _ = app_handle.emit("notes://fs", payload);
+                }
+            }
+        }
+    });
+
+    Ok(WatcherGuard {
+        root,
+        watcher: Some(watcher),
+        thread: Some(thread),
+    })
+}
+
+impl NotesWatcherState {
+    pub fn set_root(&self, app: &AppHandle, root: PathBuf) -> Result<(), String> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| "Failed to lock notes watcher state".to_string())?;
+
+        if let Some(mut existing) = guard.take() {
+            existing.stop();
+        }
+
+        let watcher = spawn_fs_watcher(app.clone(), root)
+            .map_err(|error| format!("Failed to initialize notes watcher: {error}"))?;
+
+        *guard = Some(watcher);
+
+        Ok(())
+    }
+}
+
+#[tauri::command]
+pub async fn set_notes_root(
+    path: String,
+    app: AppHandle,
+    state: State<'_, NotesWatcherState>,
+) -> Result<(), String> {
+    if path.trim().is_empty() {
+        return Err("Path must not be empty".to_string());
+    }
+
+    state.set_root(&app, PathBuf::from(path))
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import Dashboard from './routes/Dashboard'
 import Passwords from './routes/Passwords'
 import Sites from './routes/Sites'
 import Docs from './routes/Docs'
-import Inspiration from './routes/Inspiration'
+import Notes from './routes/Notes'
 import Settings from './routes/Settings'
 import { useLock } from './features/lock/LockProvider'
 import ConfirmDialog from './components/ConfirmDialog'
@@ -154,7 +154,7 @@ function AuthenticatedLayout() {
               文档管理
             </NavLink>
             <NavLink
-              to="/dashboard/inspiration"
+              to="/dashboard/notes"
               className={({ isActive }) =>
                 `rounded-full px-4 py-2 transition ${
                   isActive
@@ -163,7 +163,7 @@ function AuthenticatedLayout() {
                 }`
               }
             >
-              灵感妙记
+              笔记
             </NavLink>
             <NavLink
               to="/dashboard/settings"
@@ -261,7 +261,7 @@ export default function App() {
           <Route path="passwords" element={<Passwords />} />
           <Route path="sites" element={<Sites />} />
           <Route path="docs" element={<Docs />} />
-          <Route path="inspiration" element={<Inspiration />} />
+          <Route path="notes" element={<Notes />} />
           <Route path="settings" element={<Settings />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -9,7 +9,7 @@ import {
 import clsx from 'clsx'
 import { AlertCircle, Check, Copy as CopyIcon, Loader2 } from 'lucide-react'
 
-import { copyTextAutoClear, DEFAULT_CLIPBOARD_CLEAR_DELAY } from '../lib/clipboard'
+import { copyWithAutoClear, DEFAULT_CLIPBOARD_CLEAR_DELAY } from '../lib/clipboard'
 
 type CopySource = string | (() => string | Promise<string>)
 
@@ -96,7 +96,7 @@ export default function CopyButton({
     setIsLoading(true)
     try {
       const value = await resolveCopySource(text)
-      await copyTextAutoClear(value, clearDelay)
+      await copyWithAutoClear(value, clearDelay)
       setStatus('success')
       setErrorMessage(null)
       onCopy?.(value)

--- a/src/components/notes/Editor.tsx
+++ b/src/components/notes/Editor.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useState } from 'react'
+import clsx from 'clsx'
+import { Bold, Code2, Heading1, Heading2, Heading3, Italic, List, ListOrdered, Quote, Strikethrough } from 'lucide-react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Heading from '@tiptap/extension-heading'
+import CharacterCount from '@tiptap/extension-character-count'
+import { Markdown } from 'tiptap-markdown'
+
+import type { NoteDocument, NoteFrontMatter } from '../../lib/notes-fs'
+
+interface NotesEditorProps {
+  note: NoteDocument | null
+  onContentChange: (markdown: string) => void
+  onFrontMatterChange: (frontMatter: NoteFrontMatter) => void
+  onWordCountChange?: (words: number) => void
+}
+
+const MARKDOWN_EXTENSION = Markdown.configure({
+  html: false,
+  transformCopiedText: true,
+  transformPastedText: true,
+})
+
+export default function NotesEditor({ note, onContentChange, onFrontMatterChange, onWordCountChange }: NotesEditorProps) {
+  const [title, setTitle] = useState(note?.frontMatter.title ?? '')
+
+  useEffect(() => {
+    setTitle(note?.frontMatter.title ?? '')
+  }, [note?.path, note?.frontMatter.title])
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({ heading: false }),
+      Heading.configure({ levels: [1, 2, 3] }),
+      CharacterCount.configure(),
+      MARKDOWN_EXTENSION,
+    ],
+    content: note?.content ?? '',
+    editable: Boolean(note),
+    autofocus: false,
+    onUpdate({ editor }) {
+      const markdown = editor.storage.markdown?.getMarkdown?.() ?? editor.getText()
+      onContentChange(markdown)
+      if (onWordCountChange) {
+        const words = editor.storage.characterCount?.words?.() ?? 0
+        onWordCountChange(words)
+      }
+    },
+  })
+
+  useEffect(() => {
+    if (!editor) return
+    if (note) {
+      const currentMarkdown = editor.storage.markdown?.getMarkdown?.() ?? ''
+      if (currentMarkdown !== (note.content ?? '')) {
+        editor.commands.setContent(note.content ?? '', false)
+      }
+      editor.setEditable(true)
+    } else {
+      editor.commands.clearContent(true)
+      editor.setEditable(false)
+    }
+  }, [editor, note?.path, note?.content])
+
+  const toolbarItems = useMemo(
+    () => [
+      {
+        icon: Bold,
+        label: '加粗',
+        isActive: () => editor?.isActive('bold') ?? false,
+        action: () => editor?.chain().focus().toggleBold().run(),
+      },
+      {
+        icon: Italic,
+        label: '斜体',
+        isActive: () => editor?.isActive('italic') ?? false,
+        action: () => editor?.chain().focus().toggleItalic().run(),
+      },
+      {
+        icon: Strikethrough,
+        label: '删除线',
+        isActive: () => editor?.isActive('strike') ?? false,
+        action: () => editor?.chain().focus().toggleStrike().run(),
+      },
+      {
+        icon: Heading1,
+        label: '标题 1',
+        isActive: () => editor?.isActive('heading', { level: 1 }) ?? false,
+        action: () => editor?.chain().focus().toggleHeading({ level: 1 }).run(),
+      },
+      {
+        icon: Heading2,
+        label: '标题 2',
+        isActive: () => editor?.isActive('heading', { level: 2 }) ?? false,
+        action: () => editor?.chain().focus().toggleHeading({ level: 2 }).run(),
+      },
+      {
+        icon: Heading3,
+        label: '标题 3',
+        isActive: () => editor?.isActive('heading', { level: 3 }) ?? false,
+        action: () => editor?.chain().focus().toggleHeading({ level: 3 }).run(),
+      },
+      {
+        icon: List,
+        label: '无序列表',
+        isActive: () => editor?.isActive('bulletList') ?? false,
+        action: () => editor?.chain().focus().toggleBulletList().run(),
+      },
+      {
+        icon: ListOrdered,
+        label: '有序列表',
+        isActive: () => editor?.isActive('orderedList') ?? false,
+        action: () => editor?.chain().focus().toggleOrderedList().run(),
+      },
+      {
+        icon: Quote,
+        label: '引用',
+        isActive: () => editor?.isActive('blockquote') ?? false,
+        action: () => editor?.chain().focus().toggleBlockquote().run(),
+      },
+      {
+        icon: Code2,
+        label: '代码块',
+        isActive: () => editor?.isActive('codeBlock') ?? false,
+        action: () => editor?.chain().focus().toggleCodeBlock().run(),
+      },
+    ],
+    [editor],
+  )
+
+  const handleTitleChange = (value: string) => {
+    if (!note) return
+    setTitle(value)
+    onFrontMatterChange({
+      ...note.frontMatter,
+      title: value.trim() || note.frontMatter.title,
+    })
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {note ? (
+        <>
+          <input
+            type="text"
+            value={title}
+            onChange={event => handleTitleChange(event.target.value)}
+            placeholder="请输入标题"
+            className="mb-4 w-full rounded-xl border border-transparent bg-transparent text-2xl font-semibold text-text outline-none transition focus:border-primary/40 focus:bg-surface/60"
+          />
+          <div className="mb-3 flex flex-wrap items-center gap-2 rounded-xl border border-border/60 bg-surface/50 p-2 shadow-sm">
+            {toolbarItems.map(item => {
+              const Icon = item.icon
+              const active = item.isActive()
+              return (
+                <button
+                  key={item.label}
+                  type="button"
+                  onClick={() => {
+                    item.action()
+                  }}
+                  disabled={!editor}
+                  className={clsx(
+                    'inline-flex h-8 w-8 items-center justify-center rounded-md text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+                    active
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-muted hover:bg-surface-hover hover:text-text',
+                    !editor && 'cursor-not-allowed opacity-60',
+                  )}
+                  aria-label={item.label}
+                  title={item.label}
+                >
+                  <Icon className="h-4 w-4" />
+                </button>
+              )
+            })}
+          </div>
+          <div className="flex-1 overflow-hidden rounded-xl border border-border/60 bg-surface/70">
+            <EditorContent
+              editor={editor}
+              className="prose prose-sm h-full max-w-none overflow-y-auto px-6 py-4 text-text focus:outline-none prose-headings:mt-6 prose-headings:font-semibold prose-headings:text-text prose-p:leading-relaxed prose-a:text-primary"
+            />
+          </div>
+        </>
+      ) : (
+        <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-border/70 bg-surface/60 text-sm text-muted">
+          请选择左侧的笔记以开始编辑。
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/notes/QuickCapture.tsx
+++ b/src/components/notes/QuickCapture.tsx
@@ -1,0 +1,99 @@
+import { FormEvent, useEffect, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+
+interface QuickCaptureProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (value: string) => Promise<void>
+}
+
+export default function QuickCapture({ open, onClose, onSubmit }: QuickCaptureProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [value, setValue] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setValue('')
+      setError(null)
+      window.setTimeout(() => {
+        textareaRef.current?.focus()
+      }, 50)
+    }
+  }, [open])
+
+  if (!open) {
+    return null
+  }
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!value.trim()) {
+      setError('请输入要记录的内容')
+      return
+    }
+    try {
+      setSubmitting(true)
+      await onSubmit(value)
+      setValue('')
+      setError(null)
+      onClose()
+    } catch (submitError) {
+      console.error('Failed to quick capture note', submitError)
+      const message =
+        submitError instanceof Error ? submitError.message : '保存失败，请稍后再试。'
+      setError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur">
+      <div className="w-full max-w-lg rounded-2xl border border-border/60 bg-surface p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-text">秒记</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-muted transition hover:bg-surface-hover hover:text-text"
+            aria-label="关闭"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={event => setValue(event.target.value)}
+            rows={6}
+            placeholder="输入想法或待办，提交后将自动保存到 Inbox.md"
+            className="w-full resize-none rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
+            disabled={submitting}
+          />
+          {error ? <p className="text-xs text-red-500">{error}</p> : null}
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center justify-center rounded-lg border border-border px-4 py-2 text-sm font-medium text-text transition hover:border-border hover:bg-surface-hover"
+              disabled={submitting}
+            >
+              取消
+            </button>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-background transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={submitting}
+            >
+              {submitting ? '保存中…' : '保存到 Inbox'}
+            </button>
+          </div>
+        </form>
+        <p className="mt-3 text-xs text-muted">快捷键：Ctrl/⌘ + J 可随时打开秒记。</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/notes/Search.tsx
+++ b/src/components/notes/Search.tsx
@@ -1,0 +1,28 @@
+import { ChangeEvent } from 'react'
+import { Search as SearchIcon } from 'lucide-react'
+
+interface NotesSearchProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+export default function NotesSearch({ value, onChange, placeholder }: NotesSearchProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value)
+  }
+
+  return (
+    <label className="relative block">
+      <span className="sr-only">搜索笔记</span>
+      <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
+      <input
+        type="search"
+        value={value}
+        onChange={handleChange}
+        placeholder={placeholder ?? '搜索文件名'}
+        className="w-full rounded-xl border border-border bg-surface pl-9 pr-3 py-2 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
+      />
+    </label>
+  )
+}

--- a/src/components/notes/Tree.tsx
+++ b/src/components/notes/Tree.tsx
@@ -1,0 +1,118 @@
+import clsx from 'clsx'
+import { Folder, FileText, PencilLine, Trash2 } from 'lucide-react'
+import { useMemo } from 'react'
+
+import type { NotesTreeNode } from '../../lib/notes-fs'
+
+interface NotesTreeProps {
+  nodes: NotesTreeNode[]
+  selectedPath: string | null
+  onSelect: (path: string) => void
+  onRename: (path: string) => void
+  onDelete: (path: string) => void
+}
+
+function TreeItem({
+  node,
+  depth,
+  selectedPath,
+  onSelect,
+  onRename,
+  onDelete,
+}: {
+  node: NotesTreeNode
+  depth: number
+  selectedPath: string | null
+  onSelect: (path: string) => void
+  onRename: (path: string) => void
+  onDelete: (path: string) => void
+}) {
+  const isSelected = selectedPath === node.path
+  const paddingLeft = useMemo(() => ({ paddingLeft: `${depth * 0.75}rem` }), [depth])
+
+  return (
+    <div key={node.path} className="space-y-1" style={paddingLeft}>
+      <div
+        className={clsx(
+          'flex items-center justify-between gap-2 rounded-lg px-2 py-1 text-sm transition',
+          isSelected ? 'bg-primary/10 text-primary' : 'hover:bg-surface-hover',
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => onSelect(node.path)}
+          className={clsx(
+            'flex flex-1 items-center gap-2 text-left',
+            isSelected ? 'font-medium' : 'font-normal text-text',
+          )}
+        >
+          {node.kind === 'directory' ? (
+            <Folder className="h-4 w-4 text-muted" />
+          ) : (
+            <FileText className="h-4 w-4 text-muted" />
+          )}
+          <span className="truncate">{node.name}</span>
+        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onRename(node.path)}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted transition hover:bg-surface-hover hover:text-text"
+            aria-label="重命名"
+          >
+            <PencilLine className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(node.path)}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted transition hover:bg-red-500/10 hover:text-red-500"
+            aria-label="删除"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+      {node.children && node.children.length > 0 ? (
+        <div className="space-y-1">
+          {node.children.map(child => (
+            <TreeItem
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              selectedPath={selectedPath}
+              onSelect={onSelect}
+              onRename={onRename}
+              onDelete={onDelete}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default function NotesTree({ nodes, selectedPath, onSelect, onRename, onDelete }: NotesTreeProps) {
+  if (!nodes.length) {
+    return (
+      <div className="rounded-xl border border-dashed border-border/80 bg-surface/60 p-6 text-center text-sm text-muted">
+        当前目录下还没有笔记，点击右上角新建按钮开始创作。
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      {nodes.map(node => (
+        <TreeItem
+          key={node.path}
+          node={node}
+          depth={0}
+          selectedPath={selectedPath}
+          onSelect={onSelect}
+          onRename={onRename}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/hooks/usePasswordHealth.ts
+++ b/src/hooks/usePasswordHealth.ts
@@ -48,8 +48,8 @@ const EMPTY_STATE: PasswordHealthState = {
   isAnalyzing: false,
 }
 
-function toHex(buffer: ArrayBuffer) {
-  return Array.from(new Uint8Array(buffer))
+function toHex(bytes: Uint8Array) {
+  return Array.from(bytes)
     .map(byte => byte.toString(16).padStart(2, '0'))
     .join('')
 }
@@ -63,7 +63,7 @@ async function hashPlainText(input: string) {
     const encoder = new TextEncoder()
     const data = encoder.encode(input)
     const digest = await cryptoSource.subtle.digest('SHA-256', data)
-    return toHex(digest)
+    return toHex(new Uint8Array(digest))
   } catch (error) {
     console.warn('Failed to hash password plaintext', error)
     return null

--- a/src/lib/totp.ts
+++ b/src/lib/totp.ts
@@ -78,18 +78,18 @@ export async function generateTotp(
   const timestamp = options.timestamp ?? Date.now()
   const counter = Math.floor(timestamp / (period * 1_000))
 
-  const buffer = new ArrayBuffer(8)
-  const view = new DataView(buffer)
+  const counterBytes = new Uint8Array(8)
+  const view = new DataView(counterBytes.buffer)
   const high = Math.floor(counter / 0x1_0000_0000)
   const low = counter % 0x1_0000_0000
   view.setUint32(0, high)
   view.setUint32(4, low)
 
   const subtle = getSubtleCrypto()
-  const keyData = new ArrayBuffer(keyBytes.byteLength)
-  new Uint8Array(keyData).set(keyBytes)
+  const keyData = new Uint8Array(keyBytes.length)
+  keyData.set(keyBytes)
   const key = await subtle.importKey('raw', keyData, { name: 'HMAC', hash: 'SHA-1' }, false, ['sign'])
-  const digest = new Uint8Array(await subtle.sign('HMAC', key, buffer))
+  const digest = new Uint8Array(await subtle.sign('HMAC', key, counterBytes))
 
   if (digest.length < 4) {
     throw new Error('生成验证码失败')

--- a/src/routes/Notes.tsx
+++ b/src/routes/Notes.tsx
@@ -1,0 +1,552 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { dirname } from '@tauri-apps/api/path'
+import { listen } from '@tauri-apps/api/event'
+import { FilePlus2, FolderPlus, RefreshCw } from 'lucide-react'
+
+import NotesTree from '../components/notes/Tree'
+import NotesEditor from '../components/notes/Editor'
+import NotesSearch from '../components/notes/Search'
+import QuickCapture from '../components/notes/QuickCapture'
+import {
+  appendToInbox,
+  createFolder,
+  createNote,
+  deleteEntry,
+  describeRelativePath,
+  ensureNotesRoot,
+  loadNotesTree,
+  NoteDocument,
+  NoteFrontMatter,
+  NotesTreeNode,
+  readNoteDocument,
+  registerNotesWatcher,
+  renameEntry,
+  writeNoteDocument,
+  NOTES_ROOT_STORAGE_KEY,
+} from '../lib/notes-fs'
+import { isTauriRuntime } from '../env'
+import { useToast } from '../components/ToastProvider'
+
+const AUTO_SAVE_DELAY = 600
+
+type SaveState = 'idle' | 'pending' | 'saving' | 'saved' | 'error'
+
+function filterTree(nodes: NotesTreeNode[], keyword: string): NotesTreeNode[] {
+  const term = keyword.trim().toLowerCase()
+  if (!term) {
+    return nodes
+  }
+
+  const filterNode = (node: NotesTreeNode): NotesTreeNode | null => {
+    const nameMatch = node.name.toLowerCase().includes(term)
+    if (node.kind === 'directory') {
+      const children = (node.children ?? [])
+        .map(child => filterNode(child))
+        .filter((child): child is NotesTreeNode => Boolean(child))
+      if (nameMatch || children.length > 0) {
+        return { ...node, children }
+      }
+      return null
+    }
+
+    return nameMatch ? node : null
+  }
+
+  return nodes
+    .map(node => filterNode(node))
+    .filter((node): node is NotesTreeNode => Boolean(node))
+}
+
+function flattenPaths(nodes: NotesTreeNode[], accumulator: Set<string>) {
+  for (const node of nodes) {
+    accumulator.add(node.path)
+    if (node.children) {
+      flattenPaths(node.children, accumulator)
+    }
+  }
+}
+
+function findNodeByPath(nodes: NotesTreeNode[], target: string): NotesTreeNode | null {
+  for (const node of nodes) {
+    if (node.path === target) {
+      return node
+    }
+    if (node.children) {
+      const found = findNodeByPath(node.children, target)
+      if (found) {
+        return found
+      }
+    }
+  }
+  return null
+}
+
+export default function Notes() {
+  const [rootPath, setRootPath] = useState('')
+  const [tree, setTree] = useState<NotesTreeNode[]>([])
+  const [search, setSearch] = useState('')
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [currentNote, setCurrentNote] = useState<NoteDocument | null>(null)
+  const [saveState, setSaveState] = useState<SaveState>('idle')
+  const [wordCount, setWordCount] = useState(0)
+  const [quickCaptureOpen, setQuickCaptureOpen] = useState(false)
+  const pendingSaveRef = useRef<{ content: string; frontMatter: NoteFrontMatter } | null>(null)
+  const saveTimerRef = useRef<number | null>(null)
+  const isTauri = isTauriRuntime()
+  const { showToast } = useToast()
+
+  const refreshTree = useCallback(
+    async (targetRoot?: string) => {
+      const root = targetRoot ?? rootPath
+      if (!root) return
+      try {
+        const nodes = await loadNotesTree(root)
+        setTree(nodes)
+        if (selectedPath) {
+          const available = new Set<string>()
+          flattenPaths(nodes, available)
+          if (!available.has(selectedPath)) {
+            setSelectedPath(null)
+            setCurrentNote(null)
+            setSaveState('idle')
+          }
+        }
+      } catch (error) {
+        console.error('Failed to load notes tree', error)
+        showToast({
+          title: '加载失败',
+          description: error instanceof Error ? error.message : '读取笔记目录失败。',
+          variant: 'error',
+        })
+      }
+    },
+    [rootPath, selectedPath, showToast],
+  )
+
+  useEffect(() => {
+    if (!isTauri) return
+    let mounted = true
+    const initialize = async () => {
+      try {
+        const root = await ensureNotesRoot()
+        if (!mounted) return
+        setRootPath(root)
+        await registerNotesWatcher(root)
+        await refreshTree(root)
+      } catch (error) {
+        console.error('Failed to initialize notes root', error)
+        showToast({
+          title: '初始化失败',
+          description: error instanceof Error ? error.message : '无法准备笔记目录，请检查文件权限。',
+          variant: 'error',
+        })
+      }
+    }
+    void initialize()
+    return () => {
+      mounted = false
+    }
+  }, [isTauri, refreshTree, showToast])
+
+  useEffect(() => {
+    if (!isTauri || !rootPath) return
+    let unlisten: (() => void) | null = null
+    const setup = async () => {
+      try {
+        unlisten = await listen('notes://fs', () => {
+          void refreshTree()
+        })
+      } catch (error) {
+        console.warn('Failed to listen notes events', error)
+      }
+    }
+    void setup()
+    return () => {
+      if (unlisten) {
+        unlisten()
+      }
+    }
+  }, [isTauri, rootPath, refreshTree])
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'j') {
+        event.preventDefault()
+        setQuickCaptureOpen(true)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const listener = (event: StorageEvent) => {
+      if (event.key === NOTES_ROOT_STORAGE_KEY) {
+        const next = event.newValue?.trim()
+        if (next && next !== rootPath) {
+          setRootPath(next)
+          void registerNotesWatcher(next)
+          void refreshTree(next)
+        }
+      }
+    }
+    window.addEventListener('storage', listener)
+    return () => window.removeEventListener('storage', listener)
+  }, [refreshTree, rootPath])
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        window.clearTimeout(saveTimerRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (saveTimerRef.current) {
+      window.clearTimeout(saveTimerRef.current)
+      saveTimerRef.current = null
+    }
+    pendingSaveRef.current = null
+    setSaveState('idle')
+  }, [currentNote?.path])
+
+  const filteredTree = useMemo(() => filterTree(tree, search), [tree, search])
+
+  const handleSelect = useCallback(
+    async (path: string) => {
+      setSelectedPath(path)
+      const node = findNodeByPath(tree, path)
+      if (!node || node.kind === 'directory') {
+        setCurrentNote(null)
+        setWordCount(0)
+        return
+      }
+      try {
+        const doc = await readNoteDocument(path)
+        setCurrentNote(doc)
+        setSaveState('idle')
+        const wordEstimate = doc.content.trim() ? doc.content.trim().split(/\s+/).length : 0
+        setWordCount(wordEstimate)
+      } catch (error) {
+        console.error('Failed to load note', error)
+        showToast({
+          title: '读取笔记失败',
+          description: error instanceof Error ? error.message : '无法打开笔记文件。',
+          variant: 'error',
+        })
+      }
+    },
+    [showToast, tree],
+  )
+
+  const scheduleSave = useCallback(
+    (next: { content?: string; frontMatter?: NoteFrontMatter }) => {
+      if (!currentNote) return
+      const payload: { content: string; frontMatter: NoteFrontMatter } = {
+        content: next.content ?? currentNote.content,
+        frontMatter: next.frontMatter ?? currentNote.frontMatter,
+      }
+      pendingSaveRef.current = payload
+      setSaveState('pending')
+      if (saveTimerRef.current) {
+        window.clearTimeout(saveTimerRef.current)
+      }
+      saveTimerRef.current = window.setTimeout(async () => {
+        if (!pendingSaveRef.current) return
+        const toSave = pendingSaveRef.current
+        pendingSaveRef.current = null
+        setSaveState('saving')
+        try {
+          await writeNoteDocument(currentNote.path, toSave.content, toSave.frontMatter)
+          setCurrentNote(prev => (prev ? { ...prev, ...toSave } : prev))
+          setSaveState('saved')
+          window.setTimeout(() => {
+            setSaveState('idle')
+          }, 1500)
+          await refreshTree()
+        } catch (error) {
+          console.error('Failed to save note', error)
+          setSaveState('error')
+          showToast({
+            title: '保存失败',
+            description: error instanceof Error ? error.message : '写入文件失败，请检查目录权限。',
+            variant: 'error',
+          })
+        }
+      }, AUTO_SAVE_DELAY)
+    },
+    [currentNote, refreshTree, showToast],
+  )
+
+  const handleContentChange = useCallback(
+    (markdown: string) => {
+      if (!currentNote) return
+      setCurrentNote(prev => (prev ? { ...prev, content: markdown } : prev))
+      scheduleSave({ content: markdown })
+    },
+    [currentNote, scheduleSave],
+  )
+
+  const handleFrontMatterChange = useCallback(
+    (frontMatter: NoteFrontMatter) => {
+      if (!currentNote) return
+      setCurrentNote(prev => (prev ? { ...prev, frontMatter } : prev))
+      scheduleSave({ frontMatter })
+    },
+    [currentNote, scheduleSave],
+  )
+
+  const resolveTargetDirectory = useCallback(
+    async () => {
+      if (!selectedPath) return rootPath
+      const node = findNodeByPath(tree, selectedPath)
+      if (node?.kind === 'directory') {
+        return node.path
+      }
+      if (selectedPath) {
+        try {
+          return await dirname(selectedPath)
+        } catch (error) {
+          console.warn('Failed to resolve parent directory', error)
+        }
+      }
+      return rootPath
+    },
+    [rootPath, selectedPath, tree],
+  )
+
+  const handleCreateNote = useCallback(async () => {
+    if (!rootPath) return
+    const name = window.prompt('请输入新笔记的文件名', '新建笔记.md')
+    if (!name) return
+    try {
+      const directory = await resolveTargetDirectory()
+      const path = await createNote(rootPath, name, directory)
+      await refreshTree(rootPath)
+      await registerNotesWatcher(rootPath)
+      const doc = await readNoteDocument(path)
+      setSelectedPath(path)
+      setCurrentNote(doc)
+      setSaveState('idle')
+      showToast({
+        title: '笔记已创建',
+        description: describeRelativePath(rootPath, path),
+        variant: 'success',
+      })
+    } catch (error) {
+      console.error('Failed to create note', error)
+      showToast({
+        title: '创建失败',
+        description: error instanceof Error ? error.message : '无法创建笔记，请检查目录权限。',
+        variant: 'error',
+      })
+    }
+  }, [refreshTree, resolveTargetDirectory, rootPath, showToast])
+
+  const handleCreateFolder = useCallback(async () => {
+    if (!rootPath) return
+    const name = window.prompt('请输入新文件夹名称', '新建文件夹')
+    if (!name) return
+    try {
+      const directory = await resolveTargetDirectory()
+      const path = await createFolder(rootPath, name, directory)
+      await refreshTree(rootPath)
+      await registerNotesWatcher(rootPath)
+      setSelectedPath(path)
+      setCurrentNote(null)
+      showToast({
+        title: '文件夹已创建',
+        description: describeRelativePath(rootPath, path),
+        variant: 'success',
+      })
+    } catch (error) {
+      console.error('Failed to create folder', error)
+      showToast({
+        title: '创建失败',
+        description: error instanceof Error ? error.message : '无法创建文件夹，请检查目录权限。',
+        variant: 'error',
+      })
+    }
+  }, [refreshTree, resolveTargetDirectory, rootPath, showToast])
+
+  const handleRename = useCallback(
+    async (path: string) => {
+      const currentName = path.split(/\\|\//).pop() ?? ''
+      const nextName = window.prompt('请输入新的名称', currentName)
+      if (!nextName) return
+      try {
+        const nextPath = await renameEntry(path, nextName)
+        await refreshTree(rootPath)
+        if (selectedPath === path) {
+          setSelectedPath(nextPath)
+          if (currentNote) {
+            const doc = await readNoteDocument(nextPath)
+            setCurrentNote(doc)
+          }
+        }
+        showToast({
+          title: '重命名成功',
+          description: describeRelativePath(rootPath, nextPath),
+          variant: 'success',
+        })
+      } catch (error) {
+        console.error('Failed to rename entry', error)
+        showToast({
+          title: '重命名失败',
+          description: error instanceof Error ? error.message : '无法重命名该条目。',
+          variant: 'error',
+        })
+      }
+    },
+    [currentNote, refreshTree, rootPath, selectedPath, showToast],
+  )
+
+  const handleDelete = useCallback(
+    async (path: string) => {
+      const confirmed = window.confirm('删除后将无法恢复，确认删除吗？')
+      if (!confirmed) return
+      try {
+        await deleteEntry(path)
+        await refreshTree(rootPath)
+        if (selectedPath === path) {
+          setSelectedPath(null)
+          setCurrentNote(null)
+          setWordCount(0)
+        }
+        showToast({
+          title: '删除成功',
+          description: describeRelativePath(rootPath, path),
+          variant: 'success',
+        })
+      } catch (error) {
+        console.error('Failed to delete entry', error)
+        showToast({
+          title: '删除失败',
+          description: error instanceof Error ? error.message : '无法删除该条目。',
+          variant: 'error',
+        })
+      }
+    },
+    [refreshTree, rootPath, selectedPath, showToast],
+  )
+
+  const handleQuickCapture = useCallback(
+    async (value: string) => {
+      if (!rootPath) {
+        throw new Error('尚未配置笔记根目录')
+      }
+      await appendToInbox(rootPath, value)
+      await refreshTree(rootPath)
+      showToast({
+        title: '已写入 Inbox',
+        description: '内容已追加至 Inbox.md',
+        variant: 'success',
+      })
+    },
+    [refreshTree, rootPath, showToast],
+  )
+
+  const statusMeta = useMemo(() => {
+    if (!currentNote) {
+      return { label: '未打开', tone: 'bg-border/70' }
+    }
+    switch (saveState) {
+      case 'saving':
+        return { label: '保存中…', tone: 'bg-amber-400/80' }
+      case 'saved':
+        return { label: '已保存', tone: 'bg-emerald-400/80' }
+      case 'error':
+        return { label: '保存失败', tone: 'bg-red-500/80' }
+      case 'pending':
+        return { label: '待保存', tone: 'bg-sky-400/80' }
+      default:
+        return { label: '已就绪', tone: 'bg-primary/60' }
+    }
+  }, [currentNote, saveState])
+
+  if (!isTauri) {
+    return (
+      <div className="rounded-2xl border border-dashed border-border/80 bg-surface/60 p-10 text-center text-sm text-muted">
+        笔记功能仅在 Tauri 桌面端可用，请在桌面环境中访问。
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-[620px] flex-col gap-4">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-text">笔记</h1>
+          <p className="text-sm text-muted">本地 Markdown 双栏编辑器，支持自动保存与秒记。</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void refreshTree(rootPath)}
+            className="inline-flex items-center gap-2 rounded-xl border border-border px-4 py-2 text-sm font-medium text-text transition hover:border-border hover:bg-surface-hover"
+          >
+            <RefreshCw className="h-4 w-4" />
+            刷新
+          </button>
+          <button
+            type="button"
+            onClick={handleCreateFolder}
+            className="inline-flex items-center gap-2 rounded-xl border border-border px-4 py-2 text-sm font-medium text-text transition hover:border-border hover:bg-surface-hover"
+          >
+            <FolderPlus className="h-4 w-4" />
+            新建文件夹
+          </button>
+          <button
+            type="button"
+            onClick={handleCreateNote}
+            className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-background transition hover:bg-primary/90"
+          >
+            <FilePlus2 className="h-4 w-4" />
+            新建笔记
+          </button>
+        </div>
+      </header>
+      <div className="flex flex-1 flex-col gap-4 lg:flex-row">
+        <aside className="flex w-full flex-col rounded-2xl border border-border/60 bg-surface/70 lg:w-72">
+          <div className="border-b border-border/60 p-4">
+            <NotesSearch value={search} onChange={setSearch} />
+          </div>
+          <div className="flex-1 overflow-y-auto p-4">
+            <NotesTree
+              nodes={filteredTree}
+              selectedPath={selectedPath}
+              onSelect={handleSelect}
+              onRename={handleRename}
+              onDelete={handleDelete}
+            />
+          </div>
+        </aside>
+        <section className="flex min-h-[400px] flex-1 flex-col rounded-2xl border border-border/60 bg-surface/70 p-4">
+          <NotesEditor
+            note={currentNote}
+            onContentChange={handleContentChange}
+            onFrontMatterChange={handleFrontMatterChange}
+            onWordCountChange={setWordCount}
+          />
+        </section>
+      </div>
+      <footer className="flex flex-col gap-2 rounded-2xl border border-border/60 bg-surface/70 px-4 py-3 text-xs text-muted sm:flex-row sm:items-center sm:justify-between">
+        <span className="flex items-center gap-2">
+          <span className={`h-2.5 w-2.5 rounded-full ${statusMeta.tone}`} aria-hidden />
+          状态：{statusMeta.label}
+        </span>
+        <span>字数：{wordCount}</span>
+        <span>当前路径：{currentNote ? describeRelativePath(rootPath, currentNote.path) || currentNote.path : '未选择'}</span>
+      </footer>
+      <QuickCapture
+        open={quickCaptureOpen}
+        onClose={() => setQuickCaptureOpen(false)}
+        onSubmit={async value => {
+          await handleQuickCapture(value)
+        }}
+      />
+    </div>
+  )
+}

--- a/src/routes/Passwords.tsx
+++ b/src/routes/Passwords.tsx
@@ -9,7 +9,7 @@ import { TagFilter } from '../components/TagFilter'
 import { PasswordHealthBanner } from '../components/PasswordHealthBanner'
 import { VaultItemCard, type VaultItemAction, type VaultItemBadge } from '../components/VaultItemCard'
 import { VaultItemList } from '../components/VaultItemList'
-import { DEFAULT_CLIPBOARD_CLEAR_DELAY, copyTextAutoClear } from '../lib/clipboard'
+import { DEFAULT_CLIPBOARD_CLEAR_DELAY, copyWithAutoClear } from '../lib/clipboard'
 import { BACKUP_IMPORTED_EVENT } from '../lib/backup'
 import { decryptString, encryptString } from '../lib/crypto'
 import { generateTotp, normalizeTotpSecret } from '../lib/totp'
@@ -562,7 +562,7 @@ export default function Passwords() {
     }
     try {
       const plain = await decryptString(encryptionKey, item.passwordCipher)
-      await copyTextAutoClear(plain, DEFAULT_CLIPBOARD_CLEAR_DELAY)
+      await copyWithAutoClear(plain, DEFAULT_CLIPBOARD_CLEAR_DELAY)
       showToast({
         title: '已复制密码',
         description: `将在 ${CLIPBOARD_CLEAR_DELAY_SECONDS} 秒后自动清空剪贴板。`,
@@ -625,7 +625,7 @@ export default function Passwords() {
 
       const now = Date.now()
       const remainingMs = Math.max(1_000, entry.expiresAt - now)
-      await copyTextAutoClear(entry.code, Math.min(remainingMs, DEFAULT_CLIPBOARD_CLEAR_DELAY))
+      await copyWithAutoClear(entry.code, Math.min(remainingMs, DEFAULT_CLIPBOARD_CLEAR_DELAY))
       const secondsLeft = Math.max(1, Math.round((entry.expiresAt - Date.now()) / 1_000))
       showToast({ title: '已复制一次性验证码', description: `将在 ${secondsLeft} 秒后过期。`, variant: 'success' })
     } catch (error) {

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -49,6 +49,7 @@ import {
 import { BACKUP_IMPORTED_EVENT, importUserData } from '../lib/backup'
 import { estimatePasswordStrength, PASSWORD_STRENGTH_REQUIREMENT } from '../lib/password-utils'
 import { runScheduledBackup } from '../lib/auto-backup'
+import { ensureNotesRoot, resolveDefaultNotesRoot, saveStoredNotesRoot } from '../lib/notes-fs'
 import { DEFAULT_TIMEOUT, IDLE_TIMEOUT_OPTIONS, useIdleTimeoutStore } from '../features/lock/IdleLock'
 import { selectAuthProfile, useAuthStore } from '../stores/auth'
 import { db, type UserAvatarMeta } from '../stores/database'
@@ -864,6 +865,10 @@ function DataBackupSection() {
   const [defaultBackupPath, setDefaultBackupPath] = useState('')
   const [selectingBackupPath, setSelectingBackupPath] = useState(false)
   const [resettingBackupPath, setResettingBackupPath] = useState(false)
+  const [notesRootPath, setNotesRootPath] = useState('')
+  const [defaultNotesRoot, setDefaultNotesRoot] = useState('')
+  const [selectingNotesRoot, setSelectingNotesRoot] = useState(false)
+  const [resettingNotesRoot, setResettingNotesRoot] = useState(false)
   const [autoBackupEnabled, setAutoBackupEnabled] = useState(false)
   const [autoBackupInterval, setAutoBackupInterval] = useState<number>(AUTO_BACKUP_DEFAULT_INTERVAL)
   const [autoBackupLastSuccess, setAutoBackupLastSuccess] = useState<number | null>(null)
@@ -1407,6 +1412,29 @@ function DataBackupSection() {
     }
   }, [isTauri, persistBackupPath])
 
+  useEffect(() => {
+    if (!isTauri) return
+    let mounted = true
+
+    const initNotesRoot = async () => {
+      try {
+        const root = await ensureNotesRoot()
+        const fallback = await resolveDefaultNotesRoot()
+        if (!mounted) return
+        setNotesRootPath(root)
+        setDefaultNotesRoot(fallback)
+      } catch (error) {
+        console.error('Failed to initialize notes root directory', error)
+      }
+    }
+
+    void initNotesRoot()
+
+    return () => {
+      mounted = false
+    }
+  }, [isTauri])
+
   const applyDataPath = useCallback(
     async (targetDir: string, options: { moveExisting?: boolean } = {}) => {
       if (!targetDir) {
@@ -1569,6 +1597,55 @@ function DataBackupSection() {
       showToast({ title: '恢复失败', description: message, variant: 'error' })
     } finally {
       setResettingBackupPath(false)
+    }
+  }
+
+  const handleSelectNotesRoot = async () => {
+    if (!isTauri) return
+    try {
+      setSelectingNotesRoot(true)
+      const selection = await openDialog({ directory: true })
+      const selectedPath = Array.isArray(selection) ? selection[0] : selection
+      if (!selectedPath) {
+        return
+      }
+      await mkdir(selectedPath, { recursive: true })
+      setNotesRootPath(selectedPath)
+      saveStoredNotesRoot(selectedPath)
+      showToast({
+        title: '笔记根目录已更新',
+        description: selectedPath,
+        variant: 'success',
+      })
+    } catch (error) {
+      console.error('Failed to select notes root', error)
+      const message = error instanceof Error ? error.message : '选择笔记根目录失败，请稍后再试。'
+      showToast({ title: '选择失败', description: message, variant: 'error' })
+    } finally {
+      setSelectingNotesRoot(false)
+    }
+  }
+
+  const handleResetNotesRoot = async () => {
+    if (!isTauri) return
+    try {
+      setResettingNotesRoot(true)
+      const target = await resolveDefaultNotesRoot()
+      await mkdir(target, { recursive: true })
+      setNotesRootPath(target)
+      setDefaultNotesRoot(target)
+      saveStoredNotesRoot(target)
+      showToast({
+        title: '已恢复默认笔记目录',
+        description: target,
+        variant: 'success',
+      })
+    } catch (error) {
+      console.error('Failed to reset notes root', error)
+      const message = error instanceof Error ? error.message : '恢复默认笔记目录失败，请稍后再试。'
+      showToast({ title: '恢复失败', description: message, variant: 'error' })
+    } finally {
+      setResettingNotesRoot(false)
     }
   }
 
@@ -1939,6 +2016,48 @@ function DataBackupSection() {
               </div>
               <p className="text-xs leading-relaxed text-muted">
                 本地数据库文件（{DATABASE_FILE_NAME}）将存储在所选目录，调整后请重启应用以生效。
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <label className="text-sm font-medium text-text">笔记根目录</label>
+                <button
+                  type="button"
+                  onClick={handleResetNotesRoot}
+                  disabled={resettingNotesRoot || !defaultNotesRoot || notesRootPath === defaultNotesRoot}
+                  className={clsx(
+                    'inline-flex items-center rounded-lg border border-border px-3 py-1 text-xs font-medium transition',
+                    'hover:border-border hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60',
+                  )}
+                >
+                  {resettingNotesRoot ? '恢复中…' : '恢复默认'}
+                </button>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                <input
+                  type="text"
+                  value={notesRootPath || '尚未选择笔记目录'}
+                  readOnly
+                  className={clsx(
+                    'w-full min-w-0 truncate rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition sm:flex-1',
+                    notesRootPath ? 'focus:border-primary/60 focus:bg-surface-hover' : 'text-muted',
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={handleSelectNotesRoot}
+                  disabled={selectingNotesRoot || resettingNotesRoot}
+                  className={clsx(
+                    'inline-flex items-center justify-center rounded-xl border border-border bg-surface px-4 py-2 text-sm font-semibold text-text shadow-sm transition',
+                    'hover:border-border hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-60',
+                  )}
+                >
+                  {selectingNotesRoot ? '选择中…' : '选择目录'}
+                </button>
+              </div>
+              <p className="text-xs leading-relaxed text-muted">
+                Markdown 笔记与 Inbox 秒记内容将存储在该目录下，支持文件系统变更监听。
               </p>
             </div>
 

--- a/src/routes/Sites.tsx
+++ b/src/routes/Sites.tsx
@@ -8,7 +8,7 @@ import { Skeleton } from '../components/Skeleton'
 import { TagFilter } from '../components/TagFilter'
 import { VaultItemCard } from '../components/VaultItemCard'
 import { VaultItemList } from '../components/VaultItemList'
-import { DEFAULT_CLIPBOARD_CLEAR_DELAY, copyTextAutoClear } from '../lib/clipboard'
+import { DEFAULT_CLIPBOARD_CLEAR_DELAY, copyWithAutoClear } from '../lib/clipboard'
 import { BACKUP_IMPORTED_EVENT } from '../lib/backup'
 import { useToast } from '../components/ToastProvider'
 import { useGlobalShortcuts } from '../hooks/useGlobalShortcuts'
@@ -231,7 +231,7 @@ export default function Sites() {
   async function handleCopyUrl(item: SiteRecord) {
     if (!item.url) return
     try {
-      await copyTextAutoClear(item.url, DEFAULT_CLIPBOARD_CLEAR_DELAY)
+      await copyWithAutoClear(item.url, DEFAULT_CLIPBOARD_CLEAR_DELAY)
       showToast({ title: '链接已复制', description: '已复制到剪贴板。', variant: 'success' })
     } catch (error) {
       console.error('Failed to copy site url', error)


### PR DESCRIPTION
## Summary
- switch the notes filesystem utilities to rely on text encoders/decoders and surface read errors via console.error
- replace Buffer-dependent helpers in the GitHub backup workflow with a manual base64 encoder driven by Uint8Array chunks
- migrate remaining modules that referenced ArrayBuffer to Uint8Array utilities, including a stream-based blob reader for vault imports

## Testing
- pnpm tsc --noEmit *(fails: repository still lacks local type declarations for TipTap, gray-matter, and the clipboard plugin packages)*
- pnpm build *(fails: same TypeScript declaration gaps as above)*
- pnpm tauri build *(fails: beforeBuildCommand reruns the TypeScript build and stops on the same missing declaration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d522e1ca608331af64e03d75b3f96c