### PR TITLE
fix(tauri): use fully-qualified Emitter::emit to avoid trait scope issues

### DIFF
--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -50,11 +50,11 @@ pub fn spawn_fs_watcher(app_handle: AppHandle, root: PathBuf) -> NotifyResult<Wa
                             .collect::<Vec<String>>(),
                     )
                     .unwrap_or_else(|_| "[]".to_string());
-                    let _ = app_handle.emit("notes://fs", payload);
+                    let _ = tauri::Emitter::emit(&app_handle, "notes://fs", payload);
                 }
                 Err(err) => {
                     let payload = format!(r#"{{"error":"{}"}}"#, err);
-                    let _ = app_handle.emit("notes://fs", payload);
+                    let _ = tauri::Emitter::emit(&app_handle, "notes://fs", payload);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- call `tauri::Emitter::emit` in the notes filesystem watcher so the command compiles even when the trait is not imported

## Testing
- cargo check *(fails: requires system library `glib-2.0` via pkg-config, unavailable in container)*
- pnpm build
- pnpm tauri build --bundles nsis *(fails: bundle target `nsis` unsupported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68d54e288124833190cff64b904c9a55