### PR TITLE
fix: resolve duplicate notes fs implementations

### DIFF
--- a/src/lib/notes-fs.ts
+++ b/src/lib/notes-fs.ts
@@ -5,6 +5,7 @@ import { dump as stringifyYaml, load as parseYaml } from 'js-yaml'
 
 import { isTauriRuntime } from '../env'
 import { decodeText, encodeText } from './binary'
+import { webNotesAdapter } from './notes-storage/web'
 
 export const NOTES_ROOT_STORAGE_KEY = 'pms-notes-root'
 export const DEFAULT_NOTES_ROOT_SEGMENTS = ['use_data', 'notes'] as const
@@ -56,19 +57,18 @@ export function saveStoredNotesRoot(path: string | null): void {
   }
 }
 
-export async function resolveDefaultNotesRoot(): Promise<string> {
-  const baseDir = await homeDir()
-  return join(baseDir, ...DEFAULT_NOTES_ROOT_SEGMENTS)
-}
-
-export async function ensureNotesRoot(): Promise<string> {
-  let root = await loadStoredNotesRoot()
-  if (!root) {
-    root = await resolveDefaultNotesRoot()
-  }
-  await mkdir(root, { recursive: true })
-  saveStoredNotesRoot(root)
-  return root
+export interface NotesStorageAdapter {
+  resolveDefaultRoot(): Promise<string>
+  ensureRoot(): Promise<string>
+  loadTree(root: string): Promise<NotesTreeNode[]>
+  readDocument(path: string): Promise<NoteDocument>
+  writeDocument(path: string, content: string, frontMatter: NoteFrontMatter): Promise<void>
+  createNote(root: string, name: string, directory?: string): Promise<string>
+  createFolder(root: string, name: string, parent?: string): Promise<string>
+  deleteEntry(path: string): Promise<void>
+  renameEntry(path: string, nextName: string): Promise<string>
+  appendToInbox(root: string, body: string): Promise<void>
+  registerWatcher(path: string): Promise<void>
 }
 
 function sanitizeFileName(input: string) {
@@ -143,11 +143,6 @@ async function readDirectoryRecursive(directory: string): Promise<NotesTreeNode[
   }
 }
 
-export async function loadNotesTree(root: string): Promise<NotesTreeNode[]> {
-  await mkdir(root, { recursive: true })
-  return readDirectoryRecursive(root)
-}
-
 const FRONT_MATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/
 
 function ensureFrontMatter(data: unknown, fallbackTitle: string): NoteFrontMatter {
@@ -210,7 +205,7 @@ function buildNoteFile(content: string, frontMatter: NoteFrontMatter): string {
   return `---\n${fmSection}---\n\n${body}`
 }
 
-export async function readNoteDocument(path: string): Promise<NoteDocument> {
+async function readNoteDocumentFromFs(path: string): Promise<NoteDocument> {
   try {
     const bytes = await readFile(path)
     const raw = decodeText(bytes)
@@ -231,7 +226,11 @@ export async function readNoteDocument(path: string): Promise<NoteDocument> {
   }
 }
 
-export async function writeNoteDocument(path: string, content: string, frontMatter: NoteFrontMatter): Promise<void> {
+async function writeNoteDocumentToFs(
+  path: string,
+  content: string,
+  frontMatter: NoteFrontMatter,
+): Promise<void> {
   const normalizedFront: NoteFrontMatter = {
     ...frontMatter,
     updatedAt: new Date().toISOString(),
@@ -240,7 +239,7 @@ export async function writeNoteDocument(path: string, content: string, frontMatt
   await writeFile(path, encodeText(output))
 }
 
-export async function createNote(root: string, name: string, directory?: string): Promise<string> {
+async function createNoteOnFs(root: string, name: string, directory?: string): Promise<string> {
   const sanitized = sanitizeFileName(name)
   const baseDir = directory && directory.trim() ? directory : root
   await mkdir(baseDir, { recursive: true })
@@ -256,7 +255,7 @@ export async function createNote(root: string, name: string, directory?: string)
   return target
 }
 
-export async function createFolder(root: string, name: string, parent?: string): Promise<string> {
+async function createFolderOnFs(root: string, name: string, parent?: string): Promise<string> {
   const sanitized = sanitizeFolderName(name)
   const baseDir = parent && parent.trim() ? parent : root
   const target = await join(baseDir, sanitized)
@@ -264,11 +263,11 @@ export async function createFolder(root: string, name: string, parent?: string):
   return target
 }
 
-export async function deleteEntry(path: string): Promise<void> {
+async function deleteEntryOnFs(path: string): Promise<void> {
   await remove(path, { recursive: true })
 }
 
-export async function renameEntry(path: string, nextName: string): Promise<string> {
+async function renameEntryOnFs(path: string, nextName: string): Promise<string> {
   const parent = await dirname(path)
   const sanitized = path.toLowerCase().endsWith('.md') ? sanitizeFileName(nextName) : sanitizeFolderName(nextName)
   const target = await join(parent, sanitized)
@@ -279,13 +278,13 @@ export async function renameEntry(path: string, nextName: string): Promise<strin
   return target
 }
 
-export async function appendToInbox(root: string, body: string): Promise<void> {
+async function appendToInboxOnFs(root: string, body: string): Promise<void> {
   const inboxPath = await join(root, 'Inbox.md')
   await mkdir(root, { recursive: true })
   const existsInbox = await exists(inboxPath)
   let doc: NoteDocument
   if (existsInbox) {
-    doc = await readNoteDocument(inboxPath)
+    doc = await readNoteDocumentFromFs(inboxPath)
   } else {
     const frontMatter = buildDefaultFrontMatter('Inbox')
     await writeFile(inboxPath, encodeText(buildNoteFile('', frontMatter)))
@@ -300,19 +299,114 @@ export async function appendToInbox(root: string, body: string): Promise<void> {
   const updatedContent = doc.content
     ? `${doc.content.replace(/\s+$/g, '')}\n\n${sectionHeader}${body.trim()}\n`
     : `${sectionHeader}${body.trim()}\n`
-  await writeNoteDocument(inboxPath, updatedContent, {
+  await writeNoteDocumentToFs(inboxPath, updatedContent, {
     ...doc.frontMatter,
     updatedAt: timestamp,
   })
 }
 
-export async function registerNotesWatcher(path: string): Promise<void> {
+async function registerNotesWatcherOnFs(path: string): Promise<void> {
   if (!isTauriRuntime()) return
   try {
     await invoke('set_notes_root', { path })
   } catch (error) {
     console.warn('Failed to register notes watcher', error)
   }
+}
+
+function createTauriNotesAdapter(): NotesStorageAdapter {
+  return {
+    async resolveDefaultRoot() {
+      const baseDir = await homeDir()
+      return join(baseDir, ...DEFAULT_NOTES_ROOT_SEGMENTS)
+    },
+    async ensureRoot() {
+      let root = await loadStoredNotesRoot()
+      if (!root) {
+        root = await this.resolveDefaultRoot()
+      }
+      await mkdir(root, { recursive: true })
+      saveStoredNotesRoot(root)
+      return root
+    },
+    async loadTree(root: string) {
+      await mkdir(root, { recursive: true })
+      return readDirectoryRecursive(root)
+    },
+    readDocument: readNoteDocumentFromFs,
+    writeDocument: writeNoteDocumentToFs,
+    createNote: createNoteOnFs,
+    createFolder: createFolderOnFs,
+    deleteEntry: deleteEntryOnFs,
+    renameEntry: renameEntryOnFs,
+    appendToInbox: appendToInboxOnFs,
+    registerWatcher: registerNotesWatcherOnFs,
+  }
+}
+
+let activeNotesAdapter: NotesStorageAdapter | null = null
+
+export function setNotesStorageAdapter(adapter: NotesStorageAdapter | null) {
+  activeNotesAdapter = adapter
+}
+
+export function getNotesStorageAdapter(): NotesStorageAdapter {
+  if (activeNotesAdapter) {
+    return activeNotesAdapter
+  }
+  const adapter = isTauriRuntime() ? createTauriNotesAdapter() : webNotesAdapter
+  activeNotesAdapter = adapter
+  return adapter
+}
+
+export async function resolveDefaultNotesRoot(): Promise<string> {
+  return getNotesStorageAdapter().resolveDefaultRoot()
+}
+
+export async function ensureNotesRoot(): Promise<string> {
+  const root = await getNotesStorageAdapter().ensureRoot()
+  saveStoredNotesRoot(root)
+  return root
+}
+
+export async function loadNotesTree(root: string): Promise<NotesTreeNode[]> {
+  return getNotesStorageAdapter().loadTree(root)
+}
+
+export async function readNoteDocument(path: string): Promise<NoteDocument> {
+  return getNotesStorageAdapter().readDocument(path)
+}
+
+export async function writeNoteDocument(
+  path: string,
+  content: string,
+  frontMatter: NoteFrontMatter,
+): Promise<void> {
+  return getNotesStorageAdapter().writeDocument(path, content, frontMatter)
+}
+
+export async function createNote(root: string, name: string, directory?: string): Promise<string> {
+  return getNotesStorageAdapter().createNote(root, name, directory)
+}
+
+export async function createFolder(root: string, name: string, parent?: string): Promise<string> {
+  return getNotesStorageAdapter().createFolder(root, name, parent)
+}
+
+export async function deleteEntry(path: string): Promise<void> {
+  return getNotesStorageAdapter().deleteEntry(path)
+}
+
+export async function renameEntry(path: string, nextName: string): Promise<string> {
+  return getNotesStorageAdapter().renameEntry(path, nextName)
+}
+
+export async function appendToInbox(root: string, body: string): Promise<void> {
+  return getNotesStorageAdapter().appendToInbox(root, body)
+}
+
+export async function registerNotesWatcher(path: string): Promise<void> {
+  return getNotesStorageAdapter().registerWatcher(path)
 }
 
 export function describeRelativePath(root: string, target: string): string {

--- a/src/lib/notes-storage/web.ts
+++ b/src/lib/notes-storage/web.ts
@@ -1,0 +1,367 @@
+import type {
+  NoteDocument,
+  NoteFrontMatter,
+  NotesStorageAdapter,
+  NotesTreeNode,
+} from '../notes-fs'
+
+const WEB_NOTES_STORAGE_KEY = 'pms-web-notes-storage'
+const WEB_NOTES_ROOT = 'web-local'
+
+type StoredEntry =
+  | {
+      kind: 'directory'
+    }
+  | {
+      kind: 'file'
+      frontMatter: NoteFrontMatter
+      content: string
+    }
+
+type StoredState = Record<string, StoredEntry>
+
+const FALLBACK_STATE: StoredState = {
+  [WEB_NOTES_ROOT]: { kind: 'directory' },
+}
+
+let memoryState: StoredState | null = null
+
+function cloneState(state: StoredState): StoredState {
+  return JSON.parse(JSON.stringify(state)) as StoredState
+}
+
+function getPersistedState(): StoredState {
+  if (typeof window === 'undefined') {
+    if (!memoryState) {
+      memoryState = cloneState(FALLBACK_STATE)
+    }
+    return cloneState(memoryState)
+  }
+  try {
+    const raw = window.localStorage.getItem(WEB_NOTES_STORAGE_KEY)
+    if (typeof raw === 'string' && raw.trim()) {
+      const parsed = JSON.parse(raw) as StoredState
+      if (parsed && typeof parsed === 'object') {
+        return { ...FALLBACK_STATE, ...parsed }
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to read web notes state from storage', error)
+  }
+  return cloneState(FALLBACK_STATE)
+}
+
+function persistState(state: StoredState): void {
+  if (typeof window === 'undefined') {
+    memoryState = cloneState(state)
+    return
+  }
+  try {
+    window.localStorage.setItem(WEB_NOTES_STORAGE_KEY, JSON.stringify(state))
+  } catch (error) {
+    console.warn('Failed to persist web notes state', error)
+  }
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+function joinPath(parent: string, name: string): string {
+  const normalizedParent = normalizePath(parent)
+  const normalizedName = name.replace(/\\/g, '/').replace(/\/+$/, '')
+  if (!normalizedParent) return normalizedName
+  if (!normalizedName) return normalizedParent
+  return `${normalizedParent}/${normalizedName}`
+}
+
+function ensureDirectory(state: StoredState, path: string): void {
+  const normalized = normalizePath(path)
+  if (!normalized) return
+  if (!state[normalized]) {
+    state[normalized] = { kind: 'directory' }
+  }
+  const segments = normalized.split('/')
+  if (segments.length > 1) {
+    const parent = segments.slice(0, -1).join('/')
+    ensureDirectory(state, parent)
+  }
+}
+
+function listChildren(state: StoredState, path: string): string[] {
+  const normalized = normalizePath(path)
+  const prefix = normalized ? `${normalized}/` : ''
+  return Object.keys(state)
+    .filter(key => key.startsWith(prefix) && key !== normalized)
+    .filter(key => {
+      const remainder = key.slice(prefix.length)
+      return !remainder.includes('/')
+    })
+}
+
+function buildTree(state: StoredState, root: string): NotesTreeNode[] {
+  const normalizedRoot = normalizePath(root)
+  const queue: NotesTreeNode[] = []
+  const children = listChildren(state, normalizedRoot)
+  for (const child of children) {
+    const entry = state[child]
+    if (!entry) continue
+    if (entry.kind === 'directory') {
+      queue.push({
+        name: child.split('/').pop() ?? child,
+        path: child,
+        kind: 'directory',
+        children: buildTree(state, child),
+      })
+    } else {
+      queue.push({
+        name: child.split('/').pop() ?? child,
+        path: child,
+        kind: 'file',
+      })
+    }
+  }
+  queue.sort((a, b) => {
+    if (a.kind === b.kind) {
+      return a.name.localeCompare(b.name)
+    }
+    return a.kind === 'directory' ? -1 : 1
+  })
+  return queue
+}
+
+function sanitizeFileName(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    throw new Error('文件名不能为空')
+  }
+  const withoutInvalid = trimmed.replace(/[\\/:*?"<>|]/g, '').replace(/\s+/g, ' ').trim()
+  if (!withoutInvalid) {
+    throw new Error('文件名不能为空')
+  }
+  const normalized = withoutInvalid.replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-+|-+$/g, '')
+  const base = (normalized || withoutInvalid || 'note').slice(0, 100)
+  return base.toLowerCase().endsWith('.md') ? base : `${base}.md`
+}
+
+function sanitizeFolderName(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    throw new Error('文件夹名称不能为空')
+  }
+  const withoutInvalid = trimmed.replace(/[\\/:*?"<>|]/g, '').replace(/\s+/g, ' ').trim()
+  if (!withoutInvalid) {
+    throw new Error('文件夹名称不能为空')
+  }
+  return withoutInvalid.replace(/\s+/g, '-').replace(/-+/g, '-').replace(/^-+|-+$/g, '') || 'folder'
+}
+
+function buildDefaultFrontMatter(name: string): NoteFrontMatter {
+  const now = new Date().toISOString()
+  return {
+    title: name,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function ensureRootDirectory(state: StoredState): void {
+  ensureDirectory(state, WEB_NOTES_ROOT)
+}
+
+function ensureFrontMatter(frontMatter: NoteFrontMatter, fallback: string): NoteFrontMatter {
+  const now = new Date().toISOString()
+  const result: NoteFrontMatter = {
+    title: frontMatter.title?.trim() || fallback,
+    createdAt: frontMatter.createdAt?.trim() || now,
+    updatedAt: frontMatter.updatedAt?.trim() || now,
+  }
+  for (const [key, value] of Object.entries(frontMatter)) {
+    if (key in result) continue
+    result[key] = value
+  }
+  if (!result.createdAt) {
+    result.createdAt = now
+  }
+  if (!result.updatedAt) {
+    result.updatedAt = now
+  }
+  return result
+}
+
+function touchUpdated(frontMatter: NoteFrontMatter): NoteFrontMatter {
+  return {
+    ...frontMatter,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+function renamePath(state: StoredState, from: string, to: string): StoredState {
+  const normalizedFrom = normalizePath(from)
+  const normalizedTo = normalizePath(to)
+  if (normalizedFrom === normalizedTo) {
+    return state
+  }
+  const entries = Object.entries(state)
+  const nextState: StoredState = {}
+  for (const [key, value] of entries) {
+    if (key === normalizedFrom || key.startsWith(`${normalizedFrom}/`)) {
+      const suffix = key.slice(normalizedFrom.length)
+      nextState[`${normalizedTo}${suffix}`] = value
+    } else {
+      nextState[key] = value
+    }
+  }
+  return nextState
+}
+
+function removePath(state: StoredState, target: string): void {
+  const normalized = normalizePath(target)
+  for (const key of Object.keys(state)) {
+    if (key === normalized || key.startsWith(`${normalized}/`)) {
+      delete state[key]
+    }
+  }
+}
+
+function resolveParent(path: string): string {
+  const normalized = normalizePath(path)
+  const index = normalized.lastIndexOf('/')
+  if (index === -1) {
+    return ''
+  }
+  return normalized.slice(0, index)
+}
+
+function ensureNoteEntry(state: StoredState, path: string): NoteDocument {
+  const entry = state[path]
+  if (!entry || entry.kind !== 'file') {
+    throw new Error('找不到笔记文件')
+  }
+  const fallbackTitle = path.split('/').pop() ?? '未命名笔记'
+  const frontMatter = ensureFrontMatter(entry.frontMatter, fallbackTitle)
+  entry.frontMatter = frontMatter
+  return {
+    path,
+    frontMatter,
+    content: entry.content,
+  }
+}
+
+export const webNotesAdapter: NotesStorageAdapter = {
+  async resolveDefaultRoot() {
+    return WEB_NOTES_ROOT
+  },
+  async ensureRoot() {
+    const state = getPersistedState()
+    ensureRootDirectory(state)
+    persistState(state)
+    return WEB_NOTES_ROOT
+  },
+  async loadTree(root: string) {
+    const state = getPersistedState()
+    ensureRootDirectory(state)
+    return buildTree(state, root)
+  },
+  async readDocument(path: string) {
+    const state = getPersistedState()
+    return ensureNoteEntry(state, normalizePath(path))
+  },
+  async writeDocument(path: string, content: string, frontMatter: NoteFrontMatter) {
+    const state = getPersistedState()
+    const normalizedPath = normalizePath(path)
+    const entry = state[normalizedPath]
+    if (!entry || entry.kind !== 'file') {
+      throw new Error('找不到笔记文件')
+    }
+    entry.content = content
+    entry.frontMatter = touchUpdated({ ...entry.frontMatter, ...frontMatter })
+    persistState(state)
+  },
+  async createNote(root: string, name: string, directory?: string) {
+    const state = getPersistedState()
+    ensureRootDirectory(state)
+    const sanitized = sanitizeFileName(name)
+    const baseDir = directory ? normalizePath(directory) : normalizePath(root)
+    ensureDirectory(state, baseDir)
+    const target = joinPath(baseDir || WEB_NOTES_ROOT, sanitized)
+    if (state[target]) {
+      throw new Error('同名笔记已存在')
+    }
+    const title = sanitized.endsWith('.md') ? sanitized.slice(0, -3) : sanitized
+    state[target] = {
+      kind: 'file',
+      content: '',
+      frontMatter: buildDefaultFrontMatter(title),
+    }
+    persistState(state)
+    return target
+  },
+  async createFolder(root: string, name: string, parent?: string) {
+    const state = getPersistedState()
+    ensureRootDirectory(state)
+    const sanitized = sanitizeFolderName(name)
+    const baseDir = parent ? normalizePath(parent) : normalizePath(root)
+    ensureDirectory(state, baseDir)
+    const target = joinPath(baseDir || WEB_NOTES_ROOT, sanitized)
+    ensureDirectory(state, target)
+    persistState(state)
+    return target
+  },
+  async deleteEntry(path: string) {
+    const state = getPersistedState()
+    const normalizedPath = normalizePath(path)
+    if (!state[normalizedPath]) {
+      throw new Error('条目不存在')
+    }
+    removePath(state, normalizedPath)
+    persistState(state)
+  },
+  async renameEntry(path: string, nextName: string) {
+    const state = getPersistedState()
+    const normalizedPath = normalizePath(path)
+    const entry = state[normalizedPath]
+    if (!entry) {
+      throw new Error('条目不存在')
+    }
+    const parent = resolveParent(normalizedPath)
+    const sanitized =
+      entry.kind === 'file' ? sanitizeFileName(nextName) : sanitizeFolderName(nextName)
+    const target = parent ? joinPath(parent, sanitized) : sanitized
+    if (state[target]) {
+      throw new Error('目标名称已存在')
+    }
+    const nextState = renamePath(state, normalizedPath, target)
+    persistState(nextState)
+    return target
+  },
+  async appendToInbox(root: string, body: string) {
+    const state = getPersistedState()
+    ensureRootDirectory(state)
+    const baseDir = normalizePath(root) || WEB_NOTES_ROOT
+    ensureDirectory(state, baseDir)
+    const inboxPath = joinPath(baseDir, 'Inbox.md')
+    if (!state[inboxPath]) {
+      state[inboxPath] = {
+        kind: 'file',
+        content: '',
+        frontMatter: buildDefaultFrontMatter('Inbox'),
+      }
+    }
+    const entry = state[inboxPath]
+    if (!entry || entry.kind !== 'file') {
+      throw new Error('Inbox 条目无效')
+    }
+    const timestamp = new Date()
+    const sectionHeader = `## ${timestamp.toLocaleString()}\n\n`
+    const trimmedBody = body.trim()
+    entry.content = entry.content
+      ? `${entry.content.replace(/\s+$/g, '')}\n\n${sectionHeader}${trimmedBody}\n`
+      : `${sectionHeader}${trimmedBody}\n`
+    entry.frontMatter = touchUpdated(entry.frontMatter)
+    persistState(state)
+  },
+  async registerWatcher() {
+    return
+  },
+}


### PR DESCRIPTION
## Summary
- rename the internal filesystem helper implementations in `notes-fs` to avoid clashing with the exported adapter-forwarding functions
- update the Tauri adapter wiring and inbox helpers to use the renamed implementations

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d58fcf0d24833186b89d1c38db9e7d