### PR TITLE
Normalize tag arrays when reloading password and site lists

### DIFF
--- a/src/routes/Passwords.tsx
+++ b/src/routes/Passwords.tsx
@@ -106,7 +106,7 @@ export default function Passwords() {
       try {
         const rows = await db.passwords.where('ownerEmail').equals(currentEmail).toArray()
         rows.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-        setItems(rows)
+        setItems(rows.map(row => ({ ...row, tags: ensureTagsArray(row.tags) })))
       } finally {
         if (showLoading) {
           setLoading(false)

--- a/src/routes/Sites.tsx
+++ b/src/routes/Sites.tsx
@@ -64,7 +64,7 @@ export default function Sites() {
       try {
         const rows = await db.sites.where('ownerEmail').equals(currentEmail).toArray()
         rows.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-        setItems(rows)
+        setItems(rows.map(row => ({ ...row, tags: ensureTagsArray(row.tags) })))
       } finally {
         if (showLoading) {
           setLoading(false)


### PR DESCRIPTION
## Summary
- normalize password reload rows to ensure tag arrays match initial load logic
- apply same tag normalization for site reloads to keep filtering consistent

## Testing
- eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68d5a6729e5c8331b0868cce503c81fb