### PR TITLE
Handle storage persistence errors in web notes adapter

### DIFF
--- a/src/lib/notes-storage/web.ts
+++ b/src/lib/notes-storage/web.ts
@@ -60,6 +60,11 @@ function persistState(state: StoredState): void {
     window.localStorage.setItem(WEB_NOTES_STORAGE_KEY, JSON.stringify(state))
   } catch (error) {
     console.warn('Failed to persist web notes state', error)
+    const message =
+      error instanceof Error && error.message
+        ? `保存笔记数据失败：${error.message}`
+        : '保存笔记数据失败，请检查浏览器的存储空间或权限设置。'
+    throw new Error(message)
   }
 }
 


### PR DESCRIPTION
## Summary
- surface failures from web note persistence by rethrowing storage errors instead of silently logging them

## Testing
- `pnpm test -- --runInBand tests/notes-page.web.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d5ab8ec3308331b7a1f2269dcdb5bf