### PR TITLE
Add dev-time global error and click path logging

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,46 @@ if (!rootElement) {
   throw new Error('Failed to find the root element')
 }
 
+if (import.meta.env.DEV) {
+  window.addEventListener('error', (event) => {
+    console.error('[GlobalError]', event.error ?? event.message)
+  })
+  window.addEventListener('unhandledrejection', (event) => {
+    console.error('[UnhandledRejection]', event.reason)
+  })
+  window.addEventListener(
+    'click',
+    (event) => {
+      const path =
+        typeof event.composedPath === 'function' ? event.composedPath() : []
+      const formattedPath = path
+        .map((target) => {
+          if (target instanceof Window) return 'window'
+          if (target instanceof Document) return 'document'
+          if (target instanceof Element) {
+            const tag = target.tagName.toLowerCase()
+            const id = target.id ? `#${target.id}` : ''
+            const className = target.className
+            const classes =
+              typeof className === 'string' && className.trim().length > 0
+                ? `.${className
+                    .trim()
+                    .split(/\s+/)
+                    .filter(Boolean)
+                    .join('.')}`
+                : ''
+            return `${tag}${id}${classes}`
+          }
+          return '[unknown]'
+        })
+        .join(' > ')
+      console.log('[ClickPath]', formattedPath)
+    },
+    { capture: true },
+  )
+  // Listener cleanup isn’t necessary; they live for the app lifetime.
+}
+
 rootElement.classList.add('no-drag')
 
 // 应用首次主题


### PR DESCRIPTION
## Summary
- add development-only global listeners that log errors, promise rejections, and click paths
- capture click event composed paths to aid debugging

## Testing
- pnpm lint
- pnpm dev --host 0.0.0.0 --port 4173 --strictPort --clearScreen false (manual verification with Playwright click)


------
https://chatgpt.com/codex/tasks/task_e_68d5c89d6bac8331aafbc2ec8a9fb2f4