### PR TITLE
Add note editor drag exclusion wrappers

### DIFF
--- a/src/components/notes/QuickCapture.tsx
+++ b/src/components/notes/QuickCapture.tsx
@@ -70,7 +70,7 @@ export default function QuickCapture({ open, onClose, onSubmit }: QuickCapturePr
             onChange={event => setValue(event.target.value)}
             rows={6}
             placeholder="输入想法或待办，提交后将自动保存到 Inbox.md"
-            className="w-full resize-none rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
+            className="note-editor w-full resize-none rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text outline-none transition focus:border-primary/60 focus:bg-surface-hover"
             disabled={submitting}
           />
           {error ? <p className="text-xs text-red-500">{error}</p> : null}

--- a/src/routes/Notes.tsx
+++ b/src/routes/Notes.tsx
@@ -656,16 +656,18 @@ export default function Notes() {
                 placeholder="请输入标题"
                 className="mb-4 w-full rounded-xl border border-transparent bg-transparent text-2xl font-semibold text-text outline-none transition focus:border-primary/40 focus:bg-surface/60"
               />
-              <div className="flex-1 overflow-hidden rounded-xl border border-border/60 bg-surface/70">
-                <MdEditor
-                  value={content}
-                  onChange={handleContentChange}
-                  onPlainTextStats={stats => {
-                    setChars(stats.chars)
-                    setWords(stats.words)
-                  }}
-                  className="h-full overflow-y-auto px-6 py-4"
-                />
+              <div className="note-editor no-drag flex-1">
+                <div className="h-full overflow-hidden rounded-xl border border-border/60 bg-surface/70">
+                  <MdEditor
+                    value={content}
+                    onChange={handleContentChange}
+                    onPlainTextStats={stats => {
+                      setChars(stats.chars)
+                      setWords(stats.words)
+                    }}
+                    className="h-full overflow-y-auto px-6 py-4"
+                  />
+                </div>
               </div>
             </>
           ) : (


### PR DESCRIPTION
## Summary
- wrap the notes markdown editor in a no-drag note-editor container to enable interactions
- tag the quick capture textarea as a note-editor surface for consistent behavior

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c89c6ad483319eaff4e1215fd3eb