### PR TITLE
Ensure embedded editors opt out of drag regions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,8 +11,19 @@ a,
 input,
 textarea,
 select,
-[role="button"] {
+[role="button"],
+[contenteditable="true"] {
   -webkit-app-region: no-drag;
+}
+
+.note-editor,
+.note-editor * {
+  -webkit-app-region: no-drag;
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
+  -webkit-user-drag: auto;
+  pointer-events: auto;
 }
 
 .header-drag {


### PR DESCRIPTION
## Summary
- allow contenteditable elements to opt out of drag regions by default
- ensure the embedded note editor preserves pointer events and text selection, including Safari-specific properties

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5c89b00bc8331b97349f8f7f666eb