### PR TITLE
Fix MdEditor listener callbacks using refs

### DIFF
--- a/src/components/MdEditor.tsx
+++ b/src/components/MdEditor.tsx
@@ -15,6 +15,16 @@ export type MdEditorProps = {
 
 const Inner: FC<MdEditorProps> = ({ value, onChange, onPlainTextStats, className }) => {
   const editorRef = useRef<Editor | null>(null)
+  const onChangeRef = useRef(onChange)
+  const onPlainTextStatsRef = useRef(onPlainTextStats)
+
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  useEffect(() => {
+    onPlainTextStatsRef.current = onPlainTextStats
+  }, [onPlainTextStats])
 
   useEditor((root) => {
     const editor = Editor.make()
@@ -24,11 +34,11 @@ const Inner: FC<MdEditorProps> = ({ value, onChange, onPlainTextStats, className
         ctx.set(defaultValueCtx, value || '')
         const l = ctx.get(listenerCtx)
         l.markdownUpdated((_ctx, markdown) => {
-          onChange(markdown)
+          onChangeRef.current(markdown)
         })
         l.updated((_ctx, doc) => {
           const text = doc?.textContent ?? ''
-          onPlainTextStats?.({
+          onPlainTextStatsRef.current?.({
             text,
             chars: text.length,
             words: (text.match(/\S+/g) || []).length,


### PR DESCRIPTION
## Summary
- store the latest markdown and plain-text callbacks in refs
- update the Milkdown listener hooks to use the refs and avoid stale closures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6798978588331ae71e0eeeddf9aac