### PR TITLE
Add folder listing helper for inspiration notes

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -38,6 +38,7 @@ import {
   createNoteFile,
   createNoteFolder,
   deleteNote,
+  listNoteFolders,
   listNotes,
   loadNote,
   saveNote,
@@ -997,8 +998,22 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
     if (!isDesktop) return
     try {
       setLoadingList(true)
-      const results = await listNotes()
+      const [results, folders] = await Promise.all([listNotes(), listNoteFolders()])
       setNotes(results)
+      setExtraFolders(() => {
+        const set = new Set(
+          folders
+            .map(folder =>
+              folder
+                .split('/')
+                .map(segment => segment.trim())
+                .filter(Boolean)
+                .join('/'),
+            )
+            .filter(Boolean),
+        )
+        return Array.from(set)
+      })
       setError(null)
     } catch (err) {
       console.error('Failed to load inspiration notes', err)

--- a/tests/inspiration-panel.test.tsx
+++ b/tests/inspiration-panel.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../src/env', () => ({
 }))
 
 const listNotesMock = vi.fn<[], Promise<unknown[]>>()
+const listNoteFoldersMock = vi.fn<[], Promise<string[]>>()
 const createNoteFileMock = vi.fn<(titleOrPath: string) => Promise<string>>()
 const createNoteFolderMock = vi.fn<(path: string) => Promise<string>>()
 const loadNoteMock = vi.fn<
@@ -56,6 +57,7 @@ vi.mock('../src/lib/inspiration-notes', () => ({
   createNoteFolder: (...args: Parameters<typeof createNoteFolderMock>) =>
     createNoteFolderMock(...args),
   deleteNote: (...args: Parameters<typeof deleteNoteMock>) => deleteNoteMock(...args),
+  listNoteFolders: () => listNoteFoldersMock(),
   listNotes: () => listNotesMock(),
   loadNote: (...args: Parameters<typeof loadNoteMock>) => loadNoteMock(...args),
   saveNote: (...args: Parameters<typeof saveNoteMock>) => saveNoteMock(...args),
@@ -77,6 +79,8 @@ function renderPanel() {
 beforeEach(() => {
   listNotesMock.mockReset()
   listNotesMock.mockResolvedValue([])
+  listNoteFoldersMock.mockReset()
+  listNoteFoldersMock.mockResolvedValue([])
   createNoteFileMock.mockReset()
   createNoteFolderMock.mockReset()
   loadNoteMock.mockReset()
@@ -100,9 +104,21 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+describe('InspirationPanel folder listing', () => {
+  it('renders folders returned from listNoteFolders even when there are no notes', async () => {
+    listNoteFoldersMock.mockResolvedValue(['Ideas'])
+
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: 'Ideas' })).toBeInTheDocument()
+  })
+})
+
 describe('InspirationPanel handleCreateFolder', () => {
 
   it('creates a folder, shows success toast, and refreshes notes', async () => {
+    listNoteFoldersMock.mockResolvedValueOnce([])
+    listNoteFoldersMock.mockResolvedValueOnce(['foo/bar'])
     createNoteFolderMock.mockResolvedValue('foo/bar')
     const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('  Foo /  Bar  ')
     const user = userEvent.setup()


### PR DESCRIPTION
## Summary
- add a helper to enumerate inspiration note folders alongside existing file traversal
- update the inspiration panel refresh routine to incorporate the filesystem folder list
- extend the inspiration panel tests to verify folders render even when no notes exist

## Testing
- pnpm test -- --run tests/inspiration-panel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d762b249288331814c5bfe9fd121ce