### PR TITLE
Add desktop inspiration navigation entry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Passwords from './routes/Passwords'
 import Sites from './routes/Sites'
 import Docs from './routes/Docs'
 import Settings from './routes/Settings'
+import Inspiration from './routes/Inspiration'
 import { useLock } from './features/lock/LockProvider'
 import ConfirmDialog from './components/ConfirmDialog'
 import { isTauriRuntime } from './env'
@@ -32,6 +33,7 @@ function AuthenticatedLayout() {
   const { lock, locked } = useLock()
   const navigate = useNavigate()
   const [showPasswordReminder, setShowPasswordReminder] = useState(false)
+  const isDesktop = isTauriRuntime()
 
   const displayName = (profile?.displayName || email || '用户').trim()
   const avatarUrl = profile?.avatar?.dataUrl ?? null
@@ -152,6 +154,20 @@ function AuthenticatedLayout() {
             >
               文档管理
             </NavLink>
+            {isDesktop && (
+              <NavLink
+                to="/dashboard/inspiration"
+                className={({ isActive }) =>
+                  `rounded-full px-4 py-2 transition ${
+                    isActive
+                      ? 'bg-primary text-background'
+                      : 'text-muted hover:bg-surface-hover hover:text-text'
+                  }`
+                }
+              >
+                灵感妙记
+              </NavLink>
+            )}
             <NavLink
               to="/dashboard/settings"
               className={({ isActive }) =>
@@ -248,6 +264,7 @@ export default function App() {
           <Route path="passwords" element={<Passwords />} />
           <Route path="sites" element={<Sites />} />
           <Route path="docs" element={<Docs />} />
+          <Route path="inspiration" element={<Inspiration />} />
           <Route path="settings" element={<Settings />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/tests/app-navigation.test.tsx
+++ b/tests/app-navigation.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockInit, mockLogout } = vi.hoisted(() => ({
+  mockInit: vi.fn(async () => {}),
+  mockLogout: vi.fn(async () => {}),
+}))
+
+vi.mock('../src/env', () => ({
+  isTauriRuntime: () => true,
+}))
+
+vi.mock('../src/stores/auth', async () => {
+  const authState = {
+    email: 'user@example.com',
+    profile: {
+      email: 'user@example.com',
+      displayName: '测试用户',
+      avatar: null,
+      github: null,
+    },
+    mustChangePassword: false,
+    locked: false,
+    logout: mockLogout,
+    lockSession: () => {},
+    init: mockInit,
+    initialized: true,
+  }
+
+  const useAuthStore = ((selector: (state: typeof authState) => unknown) =>
+    selector(authState)) as unknown as typeof import('../src/stores/auth').useAuthStore
+
+  useAuthStore.getState = () => authState
+  useAuthStore.setState = (partial: Partial<typeof authState>) => {
+    Object.assign(authState, partial)
+  }
+
+  return {
+    SESSION_STORAGE_KEY: 'test-session-key',
+    useAuthStore,
+  }
+})
+
+vi.mock('../src/features/lock/LockProvider', () => ({
+  useLock: () => ({
+    lock: () => {},
+    locked: false,
+  }),
+}))
+
+vi.mock('../src/routes/Inspiration', () => ({
+  default: () => <div>Inspiration Content</div>,
+}))
+
+import App from '../src/App'
+
+describe('App navigation', () => {
+  beforeEach(() => {
+    mockInit.mockClear()
+    mockLogout.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders desktop-only inspiration link and navigates to the route', async () => {
+    const user = userEvent.setup()
+
+    render(<App />)
+
+    const inspirationLink = await screen.findByRole('link', { name: '灵感妙记' })
+    expect(inspirationLink).toBeInTheDocument()
+
+    await user.click(inspirationLink)
+
+    expect(await screen.findByText('Inspiration Content')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add the Inspiration route import to the dashboard layout and expose a desktop-only navigation link
- register the /dashboard/inspiration route so the new link resolves correctly
- add a navigation test that mocks the desktop runtime and confirms the Inspiration link renders and navigates

## Testing
- pnpm vitest run tests/app-navigation.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d76674badc8331bf25429b2be4b45f