### PR TITLE
Allow NOTES_ROOT directory access for FS plugin

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,7 +13,8 @@
       "allow": [
         { "path": "$DOCUMENT/*" },
         { "path": "$APPDATA/vault/*" },
-        { "path": "$HOME/*" }
+        { "path": "$HOME/*" },
+        { "path": "$ENV:NOTES_ROOT/**" }
       ]
     },
     {
@@ -21,21 +22,24 @@
       "allow": [
         { "path": "$DOCUMENT/*" },
         { "path": "$APPDATA/vault/*" },
-        { "path": "$HOME/*" }
+        { "path": "$HOME/*" },
+        { "path": "$ENV:NOTES_ROOT/**" }
       ]
     },
     {
       "identifier": "fs:allow-write-file",
       "allow": [
         { "path": "$APPDATA/vault/*" },
-        { "path": "$HOME/*" }
+        { "path": "$HOME/*" },
+        { "path": "$ENV:NOTES_ROOT/**" }
       ]
     },
     {
       "identifier": "fs:allow-mkdir",
       "allow": [
         { "path": "$APPDATA/vault/*" },
-        { "path": "$HOME/*" }
+        { "path": "$HOME/*" },
+        { "path": "$ENV:NOTES_ROOT/**" }
       ]
     },
     {
@@ -48,7 +52,8 @@
       "identifier": "fs:allow-exists",
       "allow": [
         { "path": "$APPDATA/vault/*" },
-        { "path": "$HOME/*" }
+        { "path": "$HOME/*" },
+        { "path": "$ENV:NOTES_ROOT/**" }
       ]
     }
   ]

--- a/src-tauri/capabilities/fs-appdata.json
+++ b/src-tauri/capabilities/fs-appdata.json
@@ -10,7 +10,8 @@
         "allow": [
           "$APPDATA/**",
           "$HOME/**",
-          "$RESOURCE/**"
+          "$RESOURCE/**",
+          "$ENV:NOTES_ROOT/**"
         ]
       }
     },


### PR DESCRIPTION
## Summary
- extend the fs-appdata capability scope to include the NOTES_ROOT directory
- allow the default capability to read, write, create, and check resources within NOTES_ROOT

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7d24b7f208331acc9e5349d1d69cb