### PR TITLE
Prevent auto-expanding collapsed inspiration folders

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -815,6 +815,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
   const skipNextAutoSaveRef = useRef(false)
   const lastAttemptedSnapshotRef = useRef<string | null>(null)
   const knownFoldersRef = useRef<Set<string>>(new Set())
+  const autoExpandedRef = useRef(false)
 
   const availableTags = useMemo(() => {
     const seen = new Set<string>()
@@ -910,12 +911,24 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
 
   useEffect(() => {
     const allPaths = collectAllFolderPaths()
-    if (!hasExpandedFolders) {
-      if (allPaths.size > 0) {
-        const initial = Array.from(allPaths).sort((a, b) => a.localeCompare(b))
-        setExpandedFolders(initial)
+
+    if (allPaths.size === 0) {
+      knownFoldersRef.current = new Set()
+      autoExpandedRef.current = false
+      if (hasExpandedFolders) {
+        setExpandedFolders([])
       }
+      return
+    }
+
+    if (!hasExpandedFolders) {
       knownFoldersRef.current = new Set(allPaths)
+      if (autoExpandedRef.current) {
+        return
+      }
+      autoExpandedRef.current = true
+      const initial = Array.from(allPaths).sort((a, b) => a.localeCompare(b))
+      setExpandedFolders(initial)
       return
     }
 

--- a/tests/inspiration-panel.test.tsx
+++ b/tests/inspiration-panel.test.tsx
@@ -122,6 +122,41 @@ describe('InspirationPanel folder listing', () => {
 
     expect(await screen.findByRole('button', { name: 'Ideas' })).toBeInTheDocument()
   })
+
+  it('keeps folders collapsed after the user closes the last expanded folder', async () => {
+    const note = {
+      id: 'Projects/Project Plan',
+      title: 'Project Plan',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      excerpt: '',
+      searchText: '',
+      tags: [],
+    }
+    listNotesMock.mockResolvedValue([note])
+    listNoteFoldersMock.mockResolvedValue(['Projects'])
+    const user = userEvent.setup()
+
+    renderPanel()
+
+    const folderButton = await screen.findByRole('button', { name: 'Projects' })
+
+    await waitFor(() => {
+      expect(folderButton).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    expect(await screen.findByRole('button', { name: /Project Plan/ })).toBeInTheDocument()
+
+    await user.click(folderButton)
+
+    await waitFor(() => {
+      expect(folderButton).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Project Plan/ })).not.toBeInTheDocument()
+    })
+  })
 })
 
 describe('InspirationPanel handleCreateFolder', () => {


### PR DESCRIPTION
## Summary
- guard the inspiration panel folder expansion effect with an auto-expansion flag so manual collapses stay closed
- reset folder tracking when the tree empties and only auto-expand on the first discovery
- cover collapsing the final folder with a dedicated regression test

## Testing
- pnpm vitest run tests/inspiration-panel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da6e5dead88331bd9c573d45365827