### PR TITLE
Handle Windows missing file errors when creating inspiration notes

### DIFF
--- a/src/lib/inspiration-notes.ts
+++ b/src/lib/inspiration-notes.ts
@@ -333,13 +333,16 @@ function extractErrorMessage(error: unknown) {
 function isMissingFsEntryError(error: unknown) {
   const message = extractErrorMessage(error)
   if (!message) return false
-  return (
-    /not found/i.test(message) ||
-    /no such file/i.test(message) ||
-    /enoent/i.test(message) ||
-    /不存在/.test(message) ||
-    /cannot find the path specified/i.test(message)
-  )
+  const missingFsErrorPatterns = [
+    /not found/i,
+    /no such file/i,
+    /enoent/i,
+    /不存在/,
+    /cannot find the path specified/i,
+    /cannot find the file specified/i,
+    /找不到指定的文件/,
+  ]
+  return missingFsErrorPatterns.some(pattern => pattern.test(message))
 }
 
 function deriveTitleFromFileName(fileName: string) {

--- a/tests/inspiration-notes.test.ts
+++ b/tests/inspiration-notes.test.ts
@@ -219,6 +219,20 @@ describe('inspiration notes storage', () => {
     await expect(createNoteFile(firstId)).rejects.toThrow('同名笔记已存在')
   })
 
+  it.each([
+    'The system cannot find the file specified.',
+    '找不到指定的文件',
+  ])('treats %s error as missing file when creating new note', async message => {
+    readTextFileMock.mockImplementationOnce(async () => {
+      throw new Error(message)
+    })
+
+    const noteId = await createNoteFile('Windows 缺失文件测试')
+
+    expect(noteId).toMatch(/\.md$/)
+    expect(writeTextFileMock).toHaveBeenCalled()
+  })
+
   it('creates nested folder structures in the local notes directory', async () => {
     const relative = await createNoteFolder('规划/2024 OKR')
     expect(relative).toBe('规划/2024-OKR')


### PR DESCRIPTION
## Summary
- expand missing file detection to cover Windows-specific error messages when creating inspiration notes
- add regression tests ensuring createNoteFile treats Windows missing file errors as recoverable

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68da6e5d18e08331b0fe0bcee9d860e3