### PR TITLE
Refine inspiration header actions layout

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -141,11 +141,11 @@ function InspirationHeader({
             集中记录灵感碎片、会议纪要与规划要点，所有 Markdown 笔记都会安全存放在本地离线数据目录，可随时备份与迁移。
           </p>
         </div>
-        <div className="flex w-full flex-wrap items-center gap-3 sm:w-auto sm:justify-end sm:gap-4">
+        <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center sm:justify-end sm:gap-4">
           <label htmlFor="inspiration-search" className="sr-only">
             搜索笔记
           </label>
-          <div className="flex w-full items-center gap-2 rounded-full border border-border bg-surface px-3 py-2 text-sm transition focus-within:border-primary/60 focus-within:bg-surface-hover sm:w-72">
+          <div className="flex w-full min-w-0 items-center gap-2 rounded-full border border-border bg-surface px-3 py-2 text-sm transition focus-within:border-primary/60 focus-within:bg-surface-hover sm:w-72 sm:flex-1">
             <SearchIcon className="h-4 w-4 text-muted" aria-hidden />
             <input
               id="inspiration-search"
@@ -173,30 +173,29 @@ function InspirationHeader({
             <button
               type="button"
               onClick={onCreateFile}
-              className="inline-flex items-center justify-center rounded-full border border-border bg-surface p-2 text-text transition hover:border-border/70 hover:bg-surface-hover"
-              aria-label="新建 Markdown 笔记"
-              title="新建 Markdown 笔记"
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text transition hover:border-border/70 hover:bg-surface-hover"
             >
               <FilePlusIcon className="h-4 w-4" aria-hidden />
+              新建笔记
+            </button>
+            <button
+              type="button"
+              onClick={onCreateFolder}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text transition hover:border-border/70 hover:bg-surface-hover"
+            >
+              <FolderPlusIcon className="h-4 w-4" aria-hidden />
+              新建文件夹
+            </button>
+            <button
+              type="button"
+              onClick={onRefresh}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text transition hover:border-border/70 hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-70"
+              disabled={loading}
+            >
+              {loading ? <LoaderIcon className="h-4 w-4 animate-spin" aria-hidden /> : <RefreshIcon className="h-4 w-4" aria-hidden />}
+              刷新列表
             </button>
           </div>
-          <button
-            type="button"
-            onClick={onCreateFolder}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text transition hover:border-border/70 hover:bg-surface-hover"
-          >
-            <FolderPlusIcon className="h-4 w-4" aria-hidden />
-            新建文件夹
-          </button>
-          <button
-            type="button"
-            onClick={onRefresh}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-text transition hover:border-border/70 hover:bg-surface-hover"
-            disabled={loading}
-          >
-            {loading ? <LoaderIcon className="h-4 w-4 animate-spin" aria-hidden /> : <RefreshIcon className="h-4 w-4" aria-hidden />}
-            刷新列表
-          </button>
         </div>
       </div>
       {error && (


### PR DESCRIPTION
## Summary
- keep inspiration header actions on a single flex row by restructuring the layout
- align the new note button styling with the folder and refresh buttons so their heights and padding match

## Testing
- eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68da9bcd518c8331a94e1d8f9ec09df6