### PR TITLE
Adjust hashtag filtering to support substring matches

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -1044,8 +1044,8 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
         if (!normalizedToken) return true
         if (isHashtagQuery) {
           return (
-            normalizedTags.some(tag => tag === normalizedToken) ||
-            excerptHashtags.some(tag => tag === normalizedToken)
+            normalizedTags.some(tag => tag.includes(normalizedToken)) ||
+            excerptHashtags.some(tag => tag.includes(normalizedToken))
           )
         }
 

--- a/tests/inspiration-panel.test.tsx
+++ b/tests/inspiration-panel.test.tsx
@@ -485,6 +485,47 @@ describe('InspirationPanel handleCreateFile', () => {
   })
 })
 
+describe('InspirationPanel search filtering', () => {
+  it('matches hashtag queries when tags contain the searched substring', async () => {
+    listNotesMock.mockResolvedValue([
+      {
+        id: 'Localization.md',
+        title: '多语言灵感',
+        createdAt: 1,
+        updatedAt: 1,
+        excerpt: '',
+        searchText: '',
+        tags: ['国际化测试'],
+      },
+      {
+        id: 'Other.md',
+        title: '日常记录',
+        createdAt: 1,
+        updatedAt: 1,
+        excerpt: '',
+        searchText: '',
+        tags: ['日志'],
+      },
+    ])
+
+    const user = userEvent.setup()
+
+    renderPanel()
+
+    await screen.findByRole('button', { name: /多语言灵感/ })
+    await screen.findByRole('button', { name: /日常记录/ })
+
+    await user.type(screen.getByPlaceholderText('搜索笔记或 #标签'), '#测试')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /多语言灵感/ })).toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /日常记录/ })).not.toBeInTheDocument()
+    })
+  })
+})
+
 describe('InspirationPanel synchronization queue', () => {
   const noteSummary = {
     id: 'Projects/Foo.md',


### PR DESCRIPTION
## Summary
- allow hashtag searches in InspirationPanel to match tag substrings instead of exact equality
- add a focused test that verifies `#测试` narrows the list to notes with matching tag text

## Testing
- pnpm vitest --run --testNamePattern "matches hashtag queries" tests/inspiration-panel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da9bccb14883318ea949464ca65e77