### PR TITLE
Align inspiration note list column with editor

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -476,7 +476,7 @@ function InspirationNoteList({
   }
 
   return (
-    <section className="flex flex-col gap-4 rounded-3xl border border-border bg-surface p-6 shadow-inner shadow-black/10 transition dark:shadow-black/40">
+    <section className="flex h-full flex-col gap-4 rounded-3xl border border-border bg-surface p-6 shadow-inner shadow-black/10 transition dark:shadow-black/40">
       <div className="flex items-center justify-between text-xs text-muted">
         <span>笔记列表</span>
         <span>{statusText}</span>
@@ -497,7 +497,7 @@ function InspirationNoteList({
             : '暂无笔记，点击“新建笔记”开始记录灵感。'}
         </div>
       ) : (
-        <div className="min-h-0 overflow-y-auto pr-1 lg:max-h-[calc(100vh-320px)]">
+        <div className="min-h-0 flex-1 overflow-y-auto pr-1 lg:max-h-[calc(100vh-320px)]">
           <div className="space-y-2">{renderNodes(tree.children, 0)}</div>
         </div>
       )}
@@ -1670,7 +1670,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
           </section>
         )}
       </div>
-      <div className="lg:col-span-1 lg:self-start">
+      <div className="flex h-full flex-col lg:col-span-1 lg:self-stretch">
         <InspirationNoteList
           notes={filteredNotes}
           totalCount={notes.length}


### PR DESCRIPTION
## Summary
- allow the inspiration note list column to stretch alongside the editor on large screens
- update the inspiration note list card to fill the column height while keeping its content scrollable

## Testing
- eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68da9bcc9b6083319afdb12e4c1c8e8c